### PR TITLE
Implement basic Api login unit test

### DIFF
--- a/backend/src/Civix/ApiBundle/Controller/SecureController.php
+++ b/backend/src/Civix/ApiBundle/Controller/SecureController.php
@@ -69,7 +69,7 @@ class SecureController extends BaseController
         // If still didn't get a entity, it is a failed authentication
         if(!$user) 
         {
-            throw new JsonResponse('Authentication failed.', 401); // @todo Only when Symfony 2.4 use Response::HTTP_UNAUTHORIZED
+            return new JsonResponse('Authentication failed.', 401); // @todo Only when Symfony 2.4 use Response::HTTP_UNAUTHORIZED
         }
         
         $encoder = $this->get('security.encoder_factory')->getEncoder($user);
@@ -80,10 +80,10 @@ class SecureController extends BaseController
             $user->generateToken();
             $em->flush();
             
-            return new JsonResponse($this->jmsSerialization($user, ['api-session']), 200); // @todo Only when Symfony 2.4 use Response::HTTP_OK
+            return new Response($this->jmsSerialization($user, ['api-session']), 200); // @todo Only when Symfony 2.4 use Response::HTTP_OK
         }
         
-        throw new JsonResponse('Authentication failed.', 401); // @todo Only when Symfony 2.4 use Response::HTTP_UNAUTHORIZED
+        return new JsonResponse('Authentication failed.', 401); // @todo Only when Symfony 2.4 use Response::HTTP_UNAUTHORIZED
     }
 
     /**

--- a/backend/src/Civix/ApiBundle/Controller/SecureController.php
+++ b/backend/src/Civix/ApiBundle/Controller/SecureController.php
@@ -30,21 +30,60 @@ class SecureController extends BaseController
 	}
 	
     /**
+     * Login a entity (User, Group, Representative or SuperUser)
+     * 
+     * Example:
+     *
+     *     curl -i -X POST -H 'application/x-www-form-urlencoded' -G 'http://domain.com/api/secure/login' -d 'username=admin&password=admin'
+     *
+     * **Input Parameters**
+     *
+     *     username: the nick for the entity
+     * 	   password: the password for the entity
+     *
+     * **Output Format**
+     *
+     * If successful:
+     *
+     *     {"token":"sometoken"}
+     *
+     * If error:
+     *
+     *     ["error","some error message"]
+     *     
      * @Route("/login", name="api_secure_login")
      * @Method("POST")
      *
      * @ApiDoc(
+     * 	   https = true,
+     *     authentication = false,
      *     resource=true,
-     *         description="Login",
-     *         filters={
-     *             {"name"="username", "dataType"="string"},
-     *             {"name"="password", "dataType"="string"}
-     *      },
-     *      statusCodes={
-     *          200="Returns authorization token",
-     *          400="Incorrect login or password",
+     *     section="Common",
+     *     description="Login",
+     *     views = { "default"},
+     *     output = "",
+     *     requirements={
+	 *     },
+     *     tags={
+	 *         "stable" = "#89BF04",
+	 *         "POST" = "#10a54a",
+	 *         "login",
+	 *     },
+     *     filters={
+     *         {"name"="username", "dataType"="string"},
+     *         {"name"="password", "dataType"="string"}
+     *     },
+     *     parameters={
+	 *     },
+     *     input = {
+	 *   	"class" = "",
+	 *	    "options" = {"method" = "POST"},
+	 *	   },
+     *     statusCodes={
+     *          200="Returned when successful with authorization token",
+     *          400="Returned when incorrect login or password",
      *          405="Method Not Allowed"
-     *      }
+     *     }
      * )
      */
     public function indexAction(Request $request)

--- a/backend/src/Civix/ApiBundle/Tests/Controller/SecureControllerTest.php
+++ b/backend/src/Civix/ApiBundle/Tests/Controller/SecureControllerTest.php
@@ -1,0 +1,146 @@
+<?php
+namespace Civix\ApiBundle\Tests\Controller;
+
+use Doctrine\ORM\EntityManager;
+
+use Liip\FunctionalTestBundle\Test\WebTestCase;
+use Civix\CoreBundle\Tests\DataFixtures\ORM\LoadGroupData;
+use Civix\CoreBundle\Tests\DataFixtures\ORM\LoadUserData;
+use Civix\CoreBundle\Tests\DataFixtures\ORM\LoadUserGroupData;
+use Civix\ApiBundle\Tests\DataFixtures\ORM\LoadSuperuserData;
+
+class UserPrePersistListenerTest extends WebTestCase
+{
+	const API_LOGIN_ENDPOINT = '/api/secure/login';
+	
+	private $client = null;
+	
+	public function setUp()
+	{
+		// Creates a initial client
+		$this->client = static::createClient();
+		
+		/** @var AbstractExecutor $fixtures */
+		$fixtures = $this->loadFixtures([
+				LoadUserData::class,
+				LoadGroupData::class,
+				LoadUserGroupData::class,
+				LoadSuperuserData::class
+		]);
+		$reference = $fixtures->getReferenceRepository();
+	}
+
+	public function tearDown()
+	{
+		// Creates a initial client
+		$this->client = NULL;
+	}
+	
+	/**
+	 * @return \PHPUnit_Framework_MockObject_MockObject|EntityManager
+	 */
+	private function getManagerMock()
+	{
+		$manager = $this->getMockBuilder(EntityManager::class)
+		->disableOriginalConstructor()
+		->getMock();
+	
+		return $manager;
+	}
+	
+	/**
+	 * @group api
+	 */
+	public function testUserLoginWithoutCredentials()
+	{
+		$this->client->request('POST', self::API_LOGIN_ENDPOINT);
+
+		$this->assertEquals(
+				401,
+				$this->client->getResponse()->getStatusCode(),
+				'Should be not authorized'
+				);
+		
+		$this->assertNotEmpty($this->client->getResponse()->headers->get('Access-Control-Allow-Origin'),
+				'Should return cors headers');
+	}
+	
+	/**
+	 * @group api
+	 */
+	public function testSuperUserLoginWithCredentials()
+	{
+		$parameters = ['username' => 'admin', 'password' => 'admin'];
+		$content = ['application/x-www-form-urlencoded'];
+		
+		$this->client->request('POST', self::API_LOGIN_ENDPOINT, $parameters, [], [], $content);
+		
+		$request_content = $this->client->getResponse()->getContent();
+		
+		$this->assertEquals(
+				200,
+				$this->client->getResponse()->getStatusCode(),
+				'Should be superuser successfully authorized'
+				);
+	
+		$this->assertNotEmpty($this->client->getResponse()->headers->get('Access-Control-Allow-Origin'),
+				'Should return cors headers');
+		
+		$data = json_decode($request_content);
+		
+		$this->assertEquals(TRUE, isset($data->token) && !empty($data->token), 'Request result should contain a token and must be not empty');
+	}
+	
+	/**
+	 * @group api
+	 */
+	public function testUserLoginWithCredentials()
+	{
+		$parameters = ['username' => 'mobile1', 'password' => 'mobile1'];
+		$content = ['application/x-www-form-urlencoded'];
+	
+		$this->client->request('POST', self::API_LOGIN_ENDPOINT, $parameters, [], [], $content);
+	
+		$request_content = $this->client->getResponse()->getContent();
+	
+		$this->assertEquals(
+				200,
+				$this->client->getResponse()->getStatusCode(),
+				'Should be superuser successfully authorized'
+				);
+	
+		$this->assertNotEmpty($this->client->getResponse()->headers->get('Access-Control-Allow-Origin'),
+				'Should return cors headers');
+	
+		$data = json_decode($request_content);
+	
+		$this->assertEquals(TRUE, isset($data->token) && !empty($data->token), 'Request result should contain a token and must be not empty');
+	}
+	
+	/**
+	 * @group api
+	 */
+	public function testGroupLoginWithCredentials()
+	{
+		$parameters = ['username' => LoadGroupData::GROUP_NAME, 'password' => LoadGroupData::GROUP_PASSWORD];
+		$content = ['application/x-www-form-urlencoded'];
+	
+		$this->client->request('POST', self::API_LOGIN_ENDPOINT, $parameters, [], [], $content);
+	
+		$request_content = $this->client->getResponse()->getContent();
+	
+		$this->assertEquals(
+				200,
+				$this->client->getResponse()->getStatusCode(),
+				'Should be superuser successfully authorized'
+				);
+	
+		$this->assertNotEmpty($this->client->getResponse()->headers->get('Access-Control-Allow-Origin'),
+				'Should return cors headers');
+	
+		$data = json_decode($request_content);
+	
+		$this->assertEquals(TRUE, isset($data->token) && !empty($data->token), 'Request result should contain a token and must be not empty');
+	}
+
+}

--- a/backend/src/Civix/ApiBundle/Tests/DataFixtures/ORM/LoadGroupData.php
+++ b/backend/src/Civix/ApiBundle/Tests/DataFixtures/ORM/LoadGroupData.php
@@ -42,6 +42,7 @@ class LoadGroupData extends AbstractFixture implements FixtureInterface, Contain
             $group->setUsername($data['username'])
                 ->setManagerEmail($data['username'].'@example.com')
                 ->setPassword($password);
+            $group->generateToken();
 
             $this->addReference('group-'.$data['username'], $group);
 

--- a/backend/src/Civix/ApiBundle/Tests/DataFixtures/ORM/LoadSuperuserData.php
+++ b/backend/src/Civix/ApiBundle/Tests/DataFixtures/ORM/LoadSuperuserData.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Civix\ApiBundle\Tests\DataFixtures\ORM;
+
+use Doctrine\Common\DataFixtures\AbstractFixture;
+use Doctrine\Common\DataFixtures\FixtureInterface;
+use Doctrine\Common\Persistence\ObjectManager;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Civix\CoreBundle\Entity\Superuser;
+
+/**
+ * LoadSuperuserData.
+ */
+class LoadSuperuserData extends AbstractFixture implements FixtureInterface, ContainerAwareInterface
+{
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+
+    public function load(ObjectManager $manager)
+    {
+        $factory = $this->container->get('security.encoder_factory');
+
+        $users [] = ['username' => 'admin'];
+        for($i = 1; $i <= 10; $i++)
+        {
+        	$users [] = ['username' => 'superuser' . $i];
+        }
+
+        foreach ($users as $data) 
+        {
+            $user = new Superuser();
+
+            $encoder = $factory->getEncoder($user);
+            $password = $encoder->encodePassword($data['username'], $user->getSalt());
+
+            $user->setUsername($data['username'])
+                ->setEmail($data['username'].'@example.com')
+                ->setPassword($password);
+            
+            $user->generateToken();
+
+            $this->addReference('superuser-'.$data['username'], $user);
+
+            $manager->persist($user);
+        }
+
+        $manager->flush();
+    }
+}

--- a/backend/src/Civix/ApiBundle/Tests/DataFixtures/ORM/LoadUserData.php
+++ b/backend/src/Civix/ApiBundle/Tests/DataFixtures/ORM/LoadUserData.php
@@ -49,6 +49,8 @@ class LoadUserData extends AbstractFixture implements FixtureInterface, Containe
             if ('mobile1' === $data['username']) {
                 $user->setResetPasswordToken(sha1($data['username']));
             }
+            
+            $user->generateToken();
 
             $this->addReference('user-'.$data['username'], $user);
 

--- a/backend/src/Civix/CoreBundle/Controller/SerializerTrait.php
+++ b/backend/src/Civix/CoreBundle/Controller/SerializerTrait.php
@@ -2,7 +2,7 @@
 
 namespace Civix\CoreBundle\Controller;
 
-use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use JMS\Serializer\SerializationContext;
 use JMS\Serializer\DeserializationContext;
 
@@ -10,17 +10,14 @@ trait SerializerTrait
 {
     protected function createJSONResponse($content = '', $status = 200)
     {
-        $response = new Response($content, $status);
-        $response->headers->set('Content-Type', 'application/json');
-
-        return $response;
+        return new JsonResponse($content, $status);;
     }
 
     protected function jmsSerialization($serializationObject, $groups, $type = 'json')
     {
         /** @var $serializer \JMS\Serializer\Serializer */
         $serializer = $this->get('jms_serializer');
-        $serializerContext = SerializationContext::create()->setGroups($groups);
+        $serializerContext = SerializationContext::create()->enableMaxDepthChecks()->setGroups($groups);
 
         return $serializer->serialize($serializationObject, $type, $serializerContext);
     }
@@ -29,7 +26,7 @@ trait SerializerTrait
     {
         /** @var $serializer \JMS\Serializer\Serializer */
         $serializer = $this->get('jms_serializer');
-        $serializerContext = DeserializationContext::create()->setGroups($groups);
+        $serializerContext = DeserializationContext::create()->enableMaxDepthChecks()->setGroups($groups);
 
         return $serializer->deserialize($content, $class, $type, $serializerContext);
     }


### PR DESCRIPTION
This PR introduce the unit testing for the basic api login types.

A example:

	vagrant@vagrant-ubuntu-trusty-64:/vagrant/backend$ phpunit --debug -c app src/Civix/ApiBundle/Tests/Controller/SecureControllerTest.php 
	PHPUnit 3.7.38 by Sebastian Bergmann.

	Configuration read from /vagrant/backend/app/phpunit.xml


	Starting test 'Civix\ApiBundle\Tests\Controller\UserPrePersistListenerTest::testUserLoginWithoutCredentials'.
	.
	Starting test 'Civix\ApiBundle\Tests\Controller\UserPrePersistListenerTest::testSuperUserLoginWithCredentials'.
	.
	Starting test 'Civix\ApiBundle\Tests\Controller\UserPrePersistListenerTest::testUserLoginWithCredentials'.
	.
	Starting test 'Civix\ApiBundle\Tests\Controller\UserPrePersistListenerTest::testGroupLoginWithCredentials'.
	.

	Time: 7.23 seconds, Memory: 66.50Mb

	OK (4 tests, 11 assertions)

Also use native JsonResponse from Symfony in JMS serializer (and avoid double json encoding), enable max depth checking (for avoid loops in objects conversion to json)

This is needed for #23 