### PR TITLE
Poll groups - Add question entry point ApiBundle from FrontendBundle

### DIFF
--- a/backend/src/Civix/ApiBundle/Controller/GroupController.php
+++ b/backend/src/Civix/ApiBundle/Controller/GroupController.php
@@ -4,6 +4,7 @@ namespace Civix\ApiBundle\Controller;
 
 use Civix\CoreBundle\Entity\Group;
 use Civix\CoreBundle\Entity\User;
+use Civix\CoreBundle\Entity\UserGroup;
 use Civix\CoreBundle\Event\GroupEvent;
 use Civix\CoreBundle\Event\GroupEvents;
 use JMS\Serializer\Exception\RuntimeException;
@@ -17,19 +18,21 @@ use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 /**
+ * Group API controller for groups
+ * 
  * @Route("/groups")
  */
 class GroupController extends BaseController
 {
     /**
-     * @Route("/", name="api_groups")
+     * @Route("/", name="civix_api_groups_by_user")
      * @Method("GET")
      */
     public function getGroupsAction()
     {
         $entityManager = $this->getDoctrine()->getManager();
 
-        $groups = $entityManager->getRepository('CivixCoreBundle:Group')
+        $groups = $entityManager->getRepository(Group::class)
                 ->getGroupsByUser($this->getUser());
 
         $response = new Response($this->jmsSerialization($groups, ['api-groups']));
@@ -39,7 +42,7 @@ class GroupController extends BaseController
     }
 
     /**
-     * @Route("/")
+     * @Route("/", name="civix_api_groups_create")
      * @Method("POST")
      */
     public function createGroupAction(Request $request)
@@ -81,19 +84,21 @@ class GroupController extends BaseController
 
         $this->get('civix_core.email_sender')
             ->sendUserRegistrationSuccessGroup($group, $password);
-        $em->getRepository('CivixCoreBundle:Group')
+        $em->getRepository(Group::class)
             ->getTotalMembers($group);
 
         return $this->createJSONResponse($this->jmsSerialization($group, ['api-info']), 201);
     }
 
     /**
-     * @Route("/user-groups/")
+     * @todo duplicate getGroupsAction?
+     * 
+     * @Route("/user-groups/", name="civix_api_groups_by_user2")
      * @Method("GET")
      */
     public function getUserGroupsAction()
     {
-        $groups = $this->getDoctrine()->getRepository('CivixCoreBundle:Group')
+        $groups = $this->getDoctrine()->getRepository(Group::class)
             ->getUserGroupsByUser($this->getUser());
 
         $response = new Response($this->jmsSerialization($groups, ['api-groups']));
@@ -103,14 +108,14 @@ class GroupController extends BaseController
     }
 
     /**
-     * @Route("/popular", name="api_popular_groups")
+     * @Route("/popular", name="civix_api_groups_popular_groups")
      * @Method("GET")
      */
     public function getPopularGroupsAction()
     {
         $entityManager = $this->getDoctrine()->getManager();
 
-        $groups = $entityManager->getRepository('CivixCoreBundle:Group')
+        $groups = $entityManager->getRepository(Group::class)
             ->getPopularGroupsByUser($this->getUser());
 
         $response = new Response($this->jmsSerialization($groups, ['api-groups']));
@@ -120,14 +125,14 @@ class GroupController extends BaseController
     }
 
     /**
-     * @Route("/new", name="api_new_groups")
+     * @Route("/new", name="civix_api_groups_new_groups")
      * @Method("GET")
      */
     public function getNewGroupsAction()
     {
         $entityManager = $this->getDoctrine()->getManager();
 
-        $groups = $entityManager->getRepository('CivixCoreBundle:Group')
+        $groups = $entityManager->getRepository(Group::class)
             ->getNewGroupsByUser($this->getUser());
 
         $response = new Response($this->jmsSerialization($groups, ['api-groups']));
@@ -137,7 +142,7 @@ class GroupController extends BaseController
     }
 
     /**
-     * @Route("/join/{id}", name="api_groups_join")
+     * @Route("/join/{id}", name="civix_api_groups_join")
      * @Method("POST")
      * @ParamConverter(
      *      "group",
@@ -227,7 +232,7 @@ class GroupController extends BaseController
 
         //check status of join
         $userGroup = $entityManager
-            ->getRepository('CivixCoreBundle:UserGroup')
+            ->getRepository(UserGroup::class)
             ->isJoinedUser($group, $user);
         $responseContentArray['status'] = $userGroup->getStatus();
 
@@ -237,7 +242,7 @@ class GroupController extends BaseController
     }
 
     /**
-     * @Route("/join/{id}", name="api_groups_unjoin")
+     * @Route("/join/{id}", name="civix_api_groups_unjoin")
      * @Method("DELETE")
      * @ParamConverter(
      *      "group",
@@ -259,7 +264,7 @@ class GroupController extends BaseController
     }
 
     /**
-     * @Route("/info/{group}", requirements={"group"="\d+"}, name="api_group_information")
+     * @Route("/info/{group}", requirements={"group"="\d+"}, name="civix_api_groups_information")
      * @Method("GET")
      * @ParamConverter("group", class="CivixCoreBundle:Group")
      */
@@ -271,7 +276,7 @@ class GroupController extends BaseController
             throw $this->createNotFoundException();
         }
 
-        $count = $entityManager->getRepository('CivixCoreBundle:Group')
+        $count = $entityManager->getRepository(Group::class)
                 ->getTotalMembers($group);
 
         $response = new Response($this->jmsSerialization($group, ['api-info']));
@@ -281,7 +286,7 @@ class GroupController extends BaseController
     }
 
     /**
-     * @Route("/invites", name="api_group_invites")
+     * @Route("/invites", name="civix_api_groups_invites")
      * @Method("GET")
      */
     public function getInvitesAction(Request $request)
@@ -296,7 +301,7 @@ class GroupController extends BaseController
      * @Route(
      *     "/invites/{status}/{group}",
      *     requirements={"group"="\d+", "status"="approve|reject"},
-     *     name="api_group_invites_approval"
+     *     name="civix_api_groups_invites_approval"
      * )
      * @Method("POST")
      * @ParamConverter("group", class="CivixCoreBundle:Group")
@@ -339,7 +344,7 @@ class GroupController extends BaseController
      * @Route(
      *     "/{group}/fields",
      *     requirements={"group"="\d+"},
-     *     name="api_group_fields"
+     *     name="civix_api_groups_fields"
      * )
      * @Method("GET")
      */
@@ -355,7 +360,7 @@ class GroupController extends BaseController
      * @Route(
      *     "/{group}/users",
      *     requirements={"group"="\d+"},
-     *     name="api_group_users"
+     *     name="civix_api_groups_users"
      * )
      * @Method("GET")
      *
@@ -383,7 +388,7 @@ class GroupController extends BaseController
     {
         $limit = $request->query->get('limit', 50);
         $page = $request->query->get('page', 1);
-        $users = $this->getDoctrine()->getRepository('CivixCoreBundle:User')
+        $users = $this->getDoctrine()->getRepository(User::class)
             ->getUsersByGroup($group, $page, $limit);
 
         $response = new Response($this->jmsSerialization($users, ['api-short-info']));

--- a/backend/src/Civix/ApiBundle/Controller/PollController.php
+++ b/backend/src/Civix/ApiBundle/Controller/PollController.php
@@ -4,6 +4,7 @@ namespace Civix\ApiBundle\Controller;
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
@@ -15,12 +16,72 @@ use Civix\CoreBundle\Entity\Poll\Answer;
 use Civix\CoreBundle\Entity\Poll\Question\PaymentRequest;
 use Civix\CoreBundle\Entity\Poll\Option;
 use Civix\CoreBundle\Entity\User;
+use Civix\CoreBundle\Entity\Poll\Question\Group as GroupQuestion;
 
 /**
  * @Route("/poll")
  */
 class PollController extends BaseController
 {
+	/**
+	 * @Route("/question/new", name="civix_api_question_new")
+	 * @Method("PUT")
+	 * 
+	 * @ParamConverter("question", class="\Civix\CoreBundle\Entity\Poll\Question\Group")
+	 * 
+	 * @ApiDoc(
+	 *     resource=true,
+	 *     description="Add a new poll question",
+	 *     statusCodes={
+	 *         200="Returns when all succesfully added",
+	 *         400="Bad Request",
+	 *         405="Method Not Allowed"
+	 *     }
+	 * )
+	 */
+	public function putQuestionNewAction(Request $request)
+	{
+		// @ŧodo Pending to use $question param as doctrine converter
+		// , \Civix\CoreBundle\Entity\Poll\Question\Group $question,  = NULL
+		
+		$manager = $this->getDoctrine()->getManager();
+
+		// Todo pending to fetch all the question data via
+		// $request->getContent() when the doctrine converter works fine
+		
+		/** @var Question $question_data */
+		/*
+		$question_data = $this->jmsDeserialization(
+				$request->getContent(),
+				'\Civix\CoreBundle\Entity\Poll\Question\Group',
+				['api-poll']
+				);
+		*/
+		
+		// Create a empty object until the $question_data could be parsed
+		$question = new GroupQuestion();
+		/* @todo
+		$question->setTitle($question_data->getTitle());
+		$question->setSubject($question_data->getSubject());
+		$question->setExpireAt($question_data->getExpireAt());
+		*/
+		
+		$this->validate($question, ['api-poll']);
+		
+		$manager->persist($question);
+		$manager->flush();
+		
+		$response = new JsonResponse();
+		$response->setContent(
+				$this->jmsSerialization(
+						$question,
+						['api-poll']
+						)
+				);
+	
+		return $response;
+	}
+	
     /**
      * Get Question by ID.
      *

--- a/backend/src/Civix/ApiBundle/Controller/UserController.php
+++ b/backend/src/Civix/ApiBundle/Controller/UserController.php
@@ -19,7 +19,7 @@ use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 class UserController extends BaseController
 {
     /**
-     * @Route("/find", name="api_user_by_username")
+     * @Route("/find", name="civix_api_user_by_username")
      * @Method("GET")
      *
      * @ApiDoc(
@@ -51,7 +51,7 @@ class UserController extends BaseController
     }
 
     /**
-     * @Route("/", name="api_users")
+     * @Route("/", name="civix_api_user_list_users")
      * @Method("GET")
      *
      * @ApiDoc(
@@ -98,7 +98,7 @@ class UserController extends BaseController
     }
 
     /**
-     * @Route("/self/subscriptions")
+     * @Route("/self/subscriptions", name="civix_api_user_self_subscriptions_activity")
      * @Method("POST")
      * 
      * @ApiDoc(

--- a/backend/src/Civix/ApiBundle/Security/Core/ApiUserProvider.php
+++ b/backend/src/Civix/ApiBundle/Security/Core/ApiUserProvider.php
@@ -40,14 +40,27 @@ class ApiUserProvider implements UserProviderInterface
 
     public function loadUserByToken(ApiToken $token)
     {
-        if (empty($token->getToken())) {
+    	// Avoid load a user if no token was provided
+        if (empty($token->getToken())) 
+        {
             return;
         }
 
-        if ($token->getUserType() === 'user') {
+        // Check first the user type
+        if ($token->getUserType() === 'user') 
+        {
             return $this->em->getRepository('CivixCoreBundle:User')
                 ->findOneBy(['token' => $token->getToken()]);
         }
+        
+        // If fails, check the group type
+        if ($token->getUserType() === 'group') 
+        {
+        	return $this->em->getRepository('CivixCoreBundle:Group')
+        	->findOneBy(['token' => $token->getToken()]);
+        }
+        
+        // @ŧodo implement here support for representative or superuser in case that needed
 
         $session = $this->em->getRepository(Session::class)
             ->findOneByToken($token->getToken());

--- a/backend/src/Civix/ApiBundle/Security/Firewall/HeaderAuthenticationListener.php
+++ b/backend/src/Civix/ApiBundle/Security/Firewall/HeaderAuthenticationListener.php
@@ -23,27 +23,63 @@ class HeaderAuthenticationListener implements ListenerInterface
         $this->authenticationManager = $authenticationManager;
     }
 
+    /**
+     * Try to autenticate a ApiToken object.
+     * 
+     * If success it sets the token in the security context and
+     * will return TRUE.
+     * 
+     * If fails, it will return FALSE.
+     * 
+     * @param ApiToken $apiToken
+     * 
+     * @return boolean
+     */
+    private function checkAuth(ApiToken $apiToken = NULL)
+    {
+    	try
+    	{
+	    	$authToken = $this->authenticationManager->authenticate($apiToken);
+	    	
+	    	$this->securityContext->setToken($authToken);
+	    	
+	    	return TRUE;
+    	}
+    	catch (AuthenticationException $failed)
+    	{
+    		return FALSE;
+    	}
+    }
+    
     public function handle(GetResponseEvent $event)
     {
         $request = $event->getRequest();
         $apiToken = null;
 
-        if ($request->headers->has('Token')) {
+        // Plain auth based in HTTP_Token header for userType = user
+        if ($request->headers->has('Token')) 
+        {
             $apiToken = new ApiToken();
             $apiToken->setToken($request->headers->get('Token'), 'user');
-        } elseif ($request->headers->has('Authorization')) {
+        } 
+        // Check auth based in Authorization header and other userType
+        elseif ($request->headers->has('Authorization')) 
+        {
             $isTokenAuth = preg_match(
                 '/^Bearer type="(?P<type>\S+?)"\s+token="(?P<token>\S+?)"$/i',
                 $request->headers->get('Authorization'),
                 $matches
             );
-            if ($isTokenAuth) {
+            if ($isTokenAuth) 
+            {
                 $apiToken = new ApiToken();
                 $apiToken->setToken($matches['token'], $matches['type']);
             }
         }
 
-        if (!$apiToken) {
+        // Check if the token was provided in some point
+        if (!$apiToken) 
+        {
             $response = new Response();
             $response->setStatusCode(401, 'Authentication required.');
             $event->setResponse($response);
@@ -51,14 +87,21 @@ class HeaderAuthenticationListener implements ListenerInterface
             return;
         }
 
-        try {
-            $authToken = $this->authenticationManager->authenticate($apiToken);
-
-            $this->securityContext->setToken($authToken);
-        } catch (AuthenticationException $failed) {
-            $response = new Response();
-            $response->setStatusCode(401, 'Incorrect Token.');
-            $event->setResponse($response);
+        // First try to authenticate with userType = user
+        if(!$this->checkAuth($apiToken))
+        {
+        	// The userType = user has failed, we check userType = group
+        	$apiToken->setToken($request->headers->get('Token'), 'group');
+        	
+        	// If group fails, we give up (@todo pending to implement representative and superuser if needed)
+        	if(!$this->checkAuth($apiToken))
+        	{
+        		$response = new Response();
+        		$response->setStatusCode(401, 'Incorrect Token or userType.');
+        		$event->setResponse($response);
+        		
+        		return;
+        	}
         }
     }
 }

--- a/backend/src/Civix/ApiBundle/Tests/Controller/PollControllerTest.php
+++ b/backend/src/Civix/ApiBundle/Tests/Controller/PollControllerTest.php
@@ -1,0 +1,102 @@
+<?php
+namespace Civix\ApiBundle\Tests\Controller;
+
+use Doctrine\ORM\EntityManager;
+
+use Civix\CoreBundle\Tests\DataFixtures\ORM\LoadGroupData;
+use Civix\CoreBundle\Tests\DataFixtures\ORM\LoadUserData;
+use Civix\CoreBundle\Tests\DataFixtures\ORM\LoadUserGroupData;
+use Civix\ApiBundle\Tests\DataFixtures\ORM\LoadSuperuserData;
+use Civix\ApiBundle\Tests\WebTestCase;
+use Civix\CoreBundle\Entity\Poll\Question;
+use Civix\CoreBundle\Entity\Poll\Question\Group as GroupQuestion;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+
+class PollControllerTest extends WebTestCase
+{
+	const API_POLL_QUESTION_NEW_ENDPOINT = '/api/poll/question/new';
+
+	/**
+	 * @var \Doctrine\ORM\EntityManager
+	 */
+	private $em;
+	
+	private $client = null;
+
+	public function setUp()
+	{
+		// Creates a initial client
+		$this->client = static::createClient();
+
+		/** @var AbstractExecutor $fixtures */
+		$fixtures = $this->loadFixtures([
+				LoadUserData::class,
+				LoadGroupData::class,
+				LoadUserGroupData::class,
+				LoadSuperuserData::class
+		]);
+		
+		$reference = $fixtures->getReferenceRepository();
+		
+		$this->em = $this->getContainer()->get('doctrine')->getManager();
+		
+		$this->group = $reference->getReference('group');
+
+		$this->group_token = $this->getUserToken($this->group->getUsername(), LoadGroupData::GROUP_PASSWORD);
+	}
+
+	public function tearDown()
+	{
+		// Creates a initial client
+		$this->client = NULL;
+	}
+	
+	/**
+	 * group api
+	 */
+	public function testAddNewQuestion()
+	{
+		$this->assertNotEmpty($this->group_token, 'Login token should not empty');
+		
+		// Create a request scope context that allows serialize the question object
+		$container = $this->getContainer();
+		
+		$request = Request::create( '/' );
+		
+		$request->setSession( new Session() );
+		$container->enterScope('request');
+		
+		$container->set('request', $request, 'request');
+		
+		$question = new GroupQuestion();
+		$question->setUser($this->group);
+
+		/*
+		 {"options":[],"educational_context":[],"is_answered":false,"cached_hash_tags":[],"user":{"id":370,"type":"group","group_type":0,"avatar_file_path":"http:\/\/localhost\/bundles\/civixfront\/img\/default_group.png"}}
+		 */
+		$content = $this->jmsSerialization($question, ['api-poll']);
+
+		$this->client->request('PUT', self::API_POLL_QUESTION_NEW_ENDPOINT, [], [], ['HTTP_Token' => $this->group_token], $content);
+		
+		$request = $this->client->getRequest();
+		
+		$response = $this->client->getResponse();
+		
+		//{"id":2,"options":[],"educational_context":[],"created_at":"Wed, 23 Mar 2016 02:25:23 +0000","is_answered":false,"cached_hash_tags":[]}
+		$content = json_decode($response->getContent());
+
+		$this->assertNotEmpty($content->created_at, 'The question object should have been created');
+		
+		// @todo implement more checks here
+	
+		$this->assertEquals(
+				200,
+				$response->getStatusCode(),
+				'Should be authorized'
+				);
+	
+		$this->assertNotEmpty($response->headers->get('Access-Control-Allow-Origin'),
+				'Should return cors headers');
+	}
+}

--- a/backend/src/Civix/ApiBundle/Tests/Controller/SecureControllerTest.php
+++ b/backend/src/Civix/ApiBundle/Tests/Controller/SecureControllerTest.php
@@ -9,7 +9,7 @@ use Civix\CoreBundle\Tests\DataFixtures\ORM\LoadUserData;
 use Civix\CoreBundle\Tests\DataFixtures\ORM\LoadUserGroupData;
 use Civix\ApiBundle\Tests\DataFixtures\ORM\LoadSuperuserData;
 
-class UserPrePersistListenerTest extends WebTestCase
+class SecureControllerTest extends WebTestCase
 {
 	const API_LOGIN_ENDPOINT = '/api/secure/login';
 	

--- a/backend/src/Civix/ApiBundle/Tests/Controller/UserControllerTest.php
+++ b/backend/src/Civix/ApiBundle/Tests/Controller/UserControllerTest.php
@@ -1,0 +1,38 @@
+<?php
+namespace Civix\ApiBundle\Tests\Controller;
+
+use Doctrine\ORM\EntityManager;
+
+use Liip\FunctionalTestBundle\Test\WebTestCase;
+use Civix\CoreBundle\Tests\DataFixtures\ORM\LoadGroupData;
+use Civix\CoreBundle\Tests\DataFixtures\ORM\LoadUserData;
+use Civix\CoreBundle\Tests\DataFixtures\ORM\LoadUserGroupData;
+use Civix\ApiBundle\Tests\DataFixtures\ORM\LoadSuperuserData;
+
+class UserControllerTest extends WebTestCase
+{
+	private $client = null;
+
+	public function setUp()
+	{
+		// Creates a initial client
+		$this->client = static::createClient();
+
+		/** @var AbstractExecutor $fixtures */
+		$fixtures = $this->loadFixtures([
+				LoadUserData::class,
+				LoadGroupData::class,
+				LoadUserGroupData::class,
+				LoadSuperuserData::class
+		]);
+		$reference = $fixtures->getReferenceRepository();
+	}
+
+	public function tearDown()
+	{
+		// Creates a initial client
+		$this->client = NULL;
+	}
+	
+	// @todo Stub test for implement in future
+}

--- a/backend/src/Civix/ApiBundle/Tests/WebTestCase.php
+++ b/backend/src/Civix/ApiBundle/Tests/WebTestCase.php
@@ -18,20 +18,7 @@ abstract class WebTestCase extends \Liip\FunctionalTestBundle\Test\WebTestCase
      */
     protected function getLoginToken($user)
     {
-        $client = static::createClient();
-        $client->request('POST', '/api/secure/login', [
-            "username" => $user->getUsername(),
-            "password" => $user->getUsername()
-        ]);
-
-        $response = $client->getResponse();
-
-        if ($response->getStatusCode() == 200) 
-        {
-            return json_decode($response->getContent())->token;
-        }
-
-        return NULL;
+    	return $this->getUserToken($user->getUsername(), $user->getUsername());
     }
     
     /**

--- a/backend/src/Civix/ApiBundle/Tests/WebTestCase.php
+++ b/backend/src/Civix/ApiBundle/Tests/WebTestCase.php
@@ -8,8 +8,13 @@ use JMS\Serializer\SerializationContext;
 abstract class WebTestCase extends \Liip\FunctionalTestBundle\Test\WebTestCase
 {
     /**
+     * Get the login token user passing the user object.
+     * 
+     * This method only will authenticate using the same
+     * password than the username.
+     * 
      * @param User $user
-     * @return string
+     * @return NULL|string
      */
     protected function getLoginToken($user)
     {
@@ -21,11 +26,38 @@ abstract class WebTestCase extends \Liip\FunctionalTestBundle\Test\WebTestCase
 
         $response = $client->getResponse();
 
-        if ($response->getStatusCode() == 200) {
+        if ($response->getStatusCode() == 200) 
+        {
             return json_decode($response->getContent())->token;
         }
 
-        return "";
+        return NULL;
+    }
+    
+    /**
+     * Get the login token user passing username and password credentials
+     * 
+     * @param string $username
+     * @param string $password
+     * 
+     * @return NULL|string
+     */
+    protected function getUserToken($username = NULL, $password = NULL)
+    {
+    	$client = static::createClient();
+    	$client->request('POST', '/api/secure/login', [
+    			'username' => $username,
+    			'password' => $password
+    	]);
+    
+    	$response = $client->getResponse();
+    
+    	if ($response->getStatusCode() == 200) 
+    	{
+    		return json_decode($response->getContent())->token;
+    	}
+    
+    	return NULL;
     }
 
     protected function jmsSerialization($serializationObject, $groups, $type = 'json')


### PR DESCRIPTION
This PR is just a enhancement that was motivated to show Jesse the new entry points that would be needed for groups passing the frontend bundle features (create a poll question as group) to api bundle.

It implements a basic unit test and add support for login groups (username/password) via API (that this would be deprecated in future, but it is needed for now for use in unit testing)