### PR TITLE
Group managers feature

### DIFF
--- a/backend/app/DoctrineMigrations/Version20160323130442.php
+++ b/backend/app/DoctrineMigrations/Version20160323130442.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20160323130442 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('CREATE TABLE users_groups_managers (id INT AUTO_INCREMENT NOT NULL, user_id INT DEFAULT NULL, group_id INT DEFAULT NULL, created_at DATETIME NOT NULL, status SMALLINT NOT NULL, INDEX IDX_A92EE543A76ED395 (user_id), INDEX IDX_A92EE543FE54D947 (group_id), UNIQUE INDEX unique_user_group (user_id, group_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE users_groups_managers ADD CONSTRAINT FK_A92EE543A76ED395 FOREIGN KEY (user_id) REFERENCES user (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE users_groups_managers ADD CONSTRAINT FK_A92EE543FE54D947 FOREIGN KEY (group_id) REFERENCES groups (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE groups CHANGE transparency transparency VARCHAR(255) NOT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP TABLE users_groups_managers');
+        $this->addSql('ALTER TABLE groups CHANGE transparency transparency VARCHAR(255) DEFAULT \'public\' NOT NULL');
+    }
+}

--- a/backend/src/Civix/ApiBundle/Controller/GroupController.php
+++ b/backend/src/Civix/ApiBundle/Controller/GroupController.php
@@ -144,6 +144,54 @@ class GroupController extends BaseController
     }
 
     /**
+     * Join a group member as group manager for a group
+     *
+     *     curl -i -X POST -G 'http://domain.com/api/groups/join-group-manager/{id}' -d ''
+     *
+     * **Input Parameters**
+     *
+     *     id: the group identifier
+     *
+     * **Output Format**
+     *
+     * If successful:
+     *
+     *     {""}
+     *
+     * If error:
+     *
+     *     ["error","some error message"]
+     *
+     * @ApiDoc(
+     * 	   https = true,
+     *     authentication = false,
+     *     resource=true,
+     *     section="Group",
+     *     description="oin a group member as group manager for a group",
+     *     views = { "default"},
+     *     output = "",
+     *     requirements={
+	 *     },
+     *     tags={
+	 *         "stable" = "#89BF04",
+	 *         "POST" = "#10a54a",
+	 *         "join group manager",
+	 *     },
+     *     filters={
+     *     },
+     *     parameters={
+	 *     },
+     *     input = {
+	 *   	"class" = "",
+	 *	    "options" = {"method" = "POST"},
+	 *	   },
+     *     statusCodes={
+     *          200="Returned when successful",
+     *          400="Returned when incorrect login or password",
+     *          405="Method Not Allowed"
+     *     }
+     * )
+     * 
      * @Route("/join-group-manager/{id}", name="civix_api_groups_join_group_manager")
      * @Method("POST")
      * @ParamConverter(

--- a/backend/src/Civix/ApiBundle/Controller/GroupController.php
+++ b/backend/src/Civix/ApiBundle/Controller/GroupController.php
@@ -58,7 +58,7 @@ class GroupController extends BaseController
      *     tags={
 	 *         "stable" = "#89BF04",
 	 *         "GET" = "#0f6ab4",
-	 *         "join group manager",
+	 *         "owner group",
 	 *     },
      *     filters={
      *     },
@@ -93,6 +93,84 @@ class GroupController extends BaseController
     		new JsonResponse(['error' => 'The user is not owner of the group'], 404);
     	}
 
+    	new JsonResponse([TRUE], 204);
+    }
+    
+    /**
+     * Checks if the current user is group member for a group given.
+     * 
+     * Note that a group owner is a group member as default definition.
+     *
+     *     curl -i -X GET -G 'http://domain.com/api/groups/is-member/{id}' -d ''
+     *
+     * **Input Parameters**
+     *
+     *     id: the group identifier
+     *
+     * **Output Format**
+     *
+     * If successful:
+     *
+     *     {"true"}
+     *
+     * If error:
+     *
+     *     ["error","some error message"]
+     *
+     * @ApiDoc(
+     * 	   https = true,
+     *     authentication = false,
+     *     resource=true,
+     *     section="Group",
+     *     description="Checks if the current user is group member for a group given.",
+     *     views = { "default"},
+     *     output = "",
+     *     requirements={
+     *     },
+     *     tags={
+     *         "stable" = "#89BF04",
+     *         "GET" = "#0f6ab4",
+     *         "memmber group",
+     *     },
+     *     filters={
+     *     },
+     *     parameters={
+     *     },
+     *     input = {
+     *   	"class" = "",
+     *	    "options" = {"method" = "GET"},
+     *	   },
+     *     statusCodes={
+     *          200="Returned when successful",
+     *          400="Returned when incorrect login or password",
+     *          405="Method Not Allowed"
+     *     }
+     * )
+     *
+     * @Route("/is-member/{id}", name="civix_api_groups_is_member")
+     * @Method("GET")
+     * @ParamConverter(
+     *      "group",
+     *      class="CivixCoreBundle:Group",
+     *      options={"repository_method" = "getGroupByIdAndType"}
+     * )
+     */
+    public function isGroupOwnerAction(Request $request, Group $group)
+    {
+    	/** @var $user User */
+    	$user = $this->getUser();
+    	 
+    	// Group owner is group member as default
+    	if($group->isOwner($user))
+    	{
+    		new JsonResponse([TRUE], 204);
+    	}
+    	
+    	if(!$group->isMember($user))
+    	{
+    		new JsonResponse(['error' => 'The user is not member of the group'], 404);
+    	}
+    
     	new JsonResponse([TRUE], 204);
     }
 	

--- a/backend/src/Civix/ApiBundle/Controller/GroupController.php
+++ b/backend/src/Civix/ApiBundle/Controller/GroupController.php
@@ -90,10 +90,10 @@ class GroupController extends BaseController
     	
     	if(!$group->isOwner($user))
     	{
-    		new JsonResponse(['error' => 'The user is not owner of the group'], 404);
+    		return new JsonResponse(['error' => 'The user is not owner of the group'], 404);
     	}
 
-    	new JsonResponse([TRUE], 204);
+    	return new JsonResponse([TRUE], 204);
     }
     
     /**
@@ -163,15 +163,15 @@ class GroupController extends BaseController
     	// Group owner is group member as default
     	if($group->isOwner($user))
     	{
-    		new JsonResponse([TRUE], 204);
+    		return new JsonResponse([TRUE], 204);
     	}
     	
     	if(!$group->isMember($user))
     	{
-    		new JsonResponse(['error' => 'The user is not member of the group'], 404);
+    		return new JsonResponse(['error' => 'The user is not member of the group'], 404);
     	}
     
-    	new JsonResponse([TRUE], 204);
+    	return new JsonResponse([TRUE], 204);
     }
 
     /**
@@ -241,15 +241,15 @@ class GroupController extends BaseController
     	// By definition, a group manager MUST BE a group member too.
    		if(!$group->isMember($user))
     	{
-    		new JsonResponse(['error' => 'The user is not member of the group'], 404);
+    		return new JsonResponse(['error' => 'The user is not member of the group'], 404);
     	}
     	
     	if(!$group->isManager($user))
     	{
-    		new JsonResponse(['error' => 'The user is not group manager of this group'], 404);
+    		return new JsonResponse(['error' => 'The user is not group manager of this group'], 404);
     	}
     
-    	new JsonResponse([TRUE], 204);
+    	return new JsonResponse([TRUE], 204);
     }
     
 	/**
@@ -530,12 +530,12 @@ class GroupController extends BaseController
     	
     	if(!$group->isMember($user))
     	{
-    		new JsonResponse(['error' => 'The user is not member of the group'], 404);
+    		return new JsonResponse(['error' => 'The user is not member of the group'], 404);
     	}
     	
     	if(!$group->isManager($user))
     	{
-    		new JsonResponse(['error' => 'The user is already group manager of this group'], 404);
+    		return new JsonResponse(['error' => 'The user is already group manager of this group'], 404);
     	}
     	
     	// Create the new relation for group and user as manager
@@ -549,7 +549,7 @@ class GroupController extends BaseController
     	$entityManager->persist($group);
     	$entityManager->flush();
     	
-    	new JsonResponse([], 204);
+    	return new JsonResponse([], 204);
     }
     
     /**

--- a/backend/src/Civix/ApiBundle/Controller/GroupController.php
+++ b/backend/src/Civix/ApiBundle/Controller/GroupController.php
@@ -27,6 +27,76 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 class GroupController extends BaseController
 {
     /**
+     * Checks if the current user is group owner for a group given
+     *
+     *     curl -i -X GET -G 'http://domain.com/api/groups/is-owner/{id}' -d ''
+     *
+     * **Input Parameters**
+     *
+     *     id: the group identifier
+     *
+     * **Output Format**
+     *
+     * If successful:
+     *
+     *     {"true"}
+     *
+     * If error:
+     *
+     *     ["error","some error message"]
+     *
+     * @ApiDoc(
+     * 	   https = true,
+     *     authentication = false,
+     *     resource=true,
+     *     section="Group",
+     *     description="Checks if the current user is group owner for a group given",
+     *     views = { "default"},
+     *     output = "",
+     *     requirements={
+	 *     },
+     *     tags={
+	 *         "stable" = "#89BF04",
+	 *         "GET" = "#0f6ab4",
+	 *         "join group manager",
+	 *     },
+     *     filters={
+     *     },
+     *     parameters={
+	 *     },
+     *     input = {
+	 *   	"class" = "",
+	 *	    "options" = {"method" = "GET"},
+	 *	   },
+     *     statusCodes={
+     *          200="Returned when successful",
+     *          400="Returned when incorrect login or password",
+     *          405="Method Not Allowed"
+     *     }
+     * )
+     * 
+     * @Route("/is-owner/{id}", name="civix_api_groups_is_owner")
+     * @Method("GET")
+     * @ParamConverter(
+     *      "group",
+     *      class="CivixCoreBundle:Group",
+     *      options={"repository_method" = "getGroupByIdAndType"}
+     * )
+     */
+    public function isGroupOwnerAction(Request $request, Group $group)
+    {
+    	/** @var $user User */
+    	$user = $this->getUser();
+    	
+    	if(!$group->isOwner($user))
+    	{
+    		new JsonResponse(['error' => 'The user is not owner of the group'], 404);
+    	}
+
+    	new JsonResponse([TRUE], 204);
+    }
+	
+	/**
      * @Route("/", name="civix_api_groups_by_user")
      * @Method("GET")
      */

--- a/backend/src/Civix/ApiBundle/Controller/GroupController.php
+++ b/backend/src/Civix/ApiBundle/Controller/GroupController.php
@@ -110,7 +110,55 @@ class GroupController extends BaseController
     }
 
     /**
-     * @Route("/popular", name="civix_api_groups_popular_groups")
+     * Fetch the groups more popular for the current user
+     *
+     *     curl -i -X POST -G 'http://domain.com/api/groups/user-groups/' -d ''
+     *
+     * **Input Parameters**
+     *
+     *     None
+     *
+     * **Output Format**
+     *
+     * If successful:
+     *
+     *     {""}
+     *
+     * If error:
+     *
+     *     ["error","some error message"]
+     *
+     * @ApiDoc(
+     * 	   https = true,
+     *     authentication = false,
+     *     resource=true,
+     *     section="Group",
+     *     description="Fetch the groups more popular for the current user",
+     *     views = { "default"},
+     *     output = "",
+     *     requirements={
+     *     },
+     *     tags={
+     *         "stable" = "#89BF04",
+     *         "GET" = "#0f6ab4",
+     *         "popular groups",
+     *     },
+     *     filters={
+     *     },
+     *     parameters={
+     *     },
+     *     input = {
+     *   	"class" = "",
+     *	    "options" = {"method" = "GET"},
+     *	   },
+     *     statusCodes={
+     *          200="Returned when successful",
+     *          400="Returned when incorrect login or password",
+     *          405="Method Not Allowed"
+     *     }
+     * )
+     *
+     * @Route("/user-groups/", name="civix_api_groups_by_user2")
      * @Method("GET")
      */
     public function getPopularGroupsAction()

--- a/backend/src/Civix/ApiBundle/Controller/GroupController.php
+++ b/backend/src/Civix/ApiBundle/Controller/GroupController.php
@@ -283,7 +283,7 @@ class GroupController extends BaseController
     }
 
     /**
-     * @Route("/join/{id}", name="civix_api_groups_unjoin")
+     * @Route("/unjoin/{id}", name="civix_api_groups_unjoin")
      * @Method("DELETE")
      * @ParamConverter(
      *      "group",

--- a/backend/src/Civix/ApiBundle/Controller/GroupController.php
+++ b/backend/src/Civix/ApiBundle/Controller/GroupController.php
@@ -130,7 +130,7 @@ class GroupController extends BaseController
      *     tags={
      *         "stable" = "#89BF04",
      *         "GET" = "#0f6ab4",
-     *         "memmber group",
+     *         "member group",
      *     },
      *     filters={
      *     },
@@ -155,7 +155,7 @@ class GroupController extends BaseController
      *      options={"repository_method" = "getGroupByIdAndType"}
      * )
      */
-    public function isGroupOwnerAction(Request $request, Group $group)
+    public function isGroupMemberAction(Request $request, Group $group)
     {
     	/** @var $user User */
     	$user = $this->getUser();
@@ -173,7 +173,85 @@ class GroupController extends BaseController
     
     	new JsonResponse([TRUE], 204);
     }
-	
+
+    /**
+     * Checks if the current user is group manager for a group given.
+     * 
+     * By definition, a group manager MUST BE a group member too.
+     *
+     *     curl -i -X GET -G 'http://domain.com/api/groups/is-manager/{id}' -d ''
+     *
+     * **Input Parameters**
+     *
+     *     id: the group identifier
+     *
+     * **Output Format**
+     *
+     * If successful:
+     *
+     *     {"true"}
+     *
+     * If error:
+     *
+     *     ["error","some error message"]
+     *
+     * @ApiDoc(
+     * 	   https = true,
+     *     authentication = false,
+     *     resource=true,
+     *     section="Group",
+     *     description="Checks if the current user is group manager for a group given.",
+     *     views = { "default"},
+     *     output = "",
+     *     requirements={
+     *     },
+     *     tags={
+     *         "stable" = "#89BF04",
+     *         "GET" = "#0f6ab4",
+     *         "manager group",
+     *     },
+     *     filters={
+     *     },
+     *     parameters={
+     *     },
+     *     input = {
+     *   	"class" = "",
+     *	    "options" = {"method" = "GET"},
+     *	   },
+     *     statusCodes={
+     *          200="Returned when successful",
+     *          400="Returned when incorrect login or password",
+     *          405="Method Not Allowed"
+     *     }
+     * )
+     *
+     * @Route("/is-manager/{id}", name="civix_api_groups_is_manager")
+     * @Method("GET")
+     * @ParamConverter(
+     *      "group",
+     *      class="CivixCoreBundle:Group",
+     *      options={"repository_method" = "getGroupByIdAndType"}
+     * )
+     */
+    public function isGroupManagerAction(Request $request, Group $group)
+    {
+    	/** @var $user User */
+    	$user = $this->getUser();
+    
+    	// By definition, a group manager MUST BE a group member too.
+   		if(!$group->isMember($user))
+    	{
+    		new JsonResponse(['error' => 'The user is not member of the group'], 404);
+    	}
+    	
+    	if(!$group->isManager($user))
+    	{
+    		new JsonResponse(['error' => 'The user is not group manager of this group'], 404);
+    	}
+    
+    	new JsonResponse([TRUE], 204);
+    }
+    
 	/**
      * @Route("/", name="civix_api_groups_by_user")
      * @Method("GET")

--- a/backend/src/Civix/ApiBundle/Controller/GroupController.php
+++ b/backend/src/Civix/ApiBundle/Controller/GroupController.php
@@ -127,6 +127,54 @@ class GroupController extends BaseController
     }
 
     /**
+     * Fetch the groups with news for the current user
+     *
+     *     curl -i -X POST -G 'http://domain.com/api/groups/new' -d ''
+     *
+     * **Input Parameters**
+     *
+     *     None
+     *
+     * **Output Format**
+     *
+     * If successful:
+     *
+     *     {""}
+     *
+     * If error:
+     *
+     *     ["error","some error message"]
+     *
+     * @ApiDoc(
+     * 	   https = true,
+     *     authentication = false,
+     *     resource=true,
+     *     section="Group",
+     *     description="Fetch the groups with news for the current user",
+     *     views = { "default"},
+     *     output = "",
+     *     requirements={
+     *     },
+     *     tags={
+     *         "stable" = "#89BF04",
+     *         "GET" = "#0f6ab4",
+     *         "new group",
+     *     },
+     *     filters={
+     *     },
+     *     parameters={
+     *     },
+     *     input = {
+     *   	"class" = "",
+     *	    "options" = {"method" = "GET"},
+     *	   },
+     *     statusCodes={
+     *          200="Returned when successful",
+     *          400="Returned when incorrect login or password",
+     *          405="Method Not Allowed"
+     *     }
+     * )
+     *
      * @Route("/new", name="civix_api_groups_new_groups")
      * @Method("GET")
      */

--- a/backend/src/Civix/ApiBundle/Tests/Controller/GroupControllerTest.php
+++ b/backend/src/Civix/ApiBundle/Tests/Controller/GroupControllerTest.php
@@ -1,0 +1,126 @@
+<?php
+namespace Civix\ApiBundle\Tests\Controller;
+
+use Doctrine\ORM\EntityManager;
+
+use Civix\CoreBundle\Tests\DataFixtures\ORM\LoadGroupData;
+use Civix\CoreBundle\Tests\DataFixtures\ORM\LoadUserData;
+use Civix\CoreBundle\Tests\DataFixtures\ORM\LoadUserGroupData;
+use Civix\ApiBundle\Tests\DataFixtures\ORM\LoadSuperuserData;
+use Civix\ApiBundle\Tests\WebTestCase;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+
+class GroupControllerTest extends WebTestCase
+{
+	const API_GROUP_IS_OWNER_ENDPOINT   = '/api/groups/is-owner';
+	const API_GROUP_IS_MEMBER_ENDPOINT  = '/api/groups/is-member';
+	const API_GROUP_IS_MANAGER_ENDPOINT = '/api/groups/is-manager';
+	
+	/**
+	 * @var \Doctrine\ORM\EntityManager
+	 */
+	private $em;
+	
+	private $client = null;
+
+	public function setUp()
+	{
+		// Creates a initial client
+		$this->client = static::createClient();
+
+		/** @var AbstractExecutor $fixtures */
+		$fixtures = $this->loadFixtures([
+				LoadUserData::class,
+				LoadGroupData::class,
+				LoadUserGroupData::class,
+				LoadSuperuserData::class
+		]);
+		
+		$reference = $fixtures->getReferenceRepository();
+		
+		$this->em = $this->getContainer()->get('doctrine')->getManager();
+		
+		$this->group = $reference->getReference('group');
+		
+		$this->mobile1 = $reference->getReference('followertest');
+		
+		$this->mobile1_token = $this->getUserToken($this->mobile1->getUsername(), $this->mobile1->getUsername());
+	}
+
+	public function tearDown()
+	{
+		// Creates a initial client
+		$this->client = NULL;
+	}
+	
+	/**
+	 * group api
+	 */
+	public function testGroupIsOwner()
+	{
+		$this->assertNotEmpty($this->mobile1_token, 'Login token should not empty');
+		
+		// Create a request scope context that allows serialize the question object
+		$container = $this->getContainer();
+		
+		$request = Request::create('/');
+		
+		$request->setSession( new Session() );
+		$container->enterScope('request');
+		
+		$container->set('request', $request, 'request');
+		
+		$content = [];
+		
+		// Test is owner endpoint for failed result
+		$end_point = self::API_GROUP_IS_OWNER_ENDPOINT . '/' . $this->group->getId();
+		
+		$this->client->request('GET', $end_point, [], [], ['HTTP_Token' => $this->mobile1_token], $content);
+		
+		$request = $this->client->getRequest();
+		
+		$response = $this->client->getResponse();
+		
+		$content = json_decode($response->getContent());
+
+		$this->assertNotEmpty($content->error, 'The user is not owner of the group');
+		
+		$this->assertEquals(
+				404,
+				$response->getStatusCode(),
+				'Should be a 404 response'
+				);
+		
+		$this->assertNotEmpty($response->headers->get('Access-Control-Allow-Origin'),
+				'Should return cors headers');
+		
+		// Set as owner of the group the mobile user
+		$this->group->setOwner($this->mobile1);
+
+		$this->em->flush($this->group);
+		
+		// Test is owner endpoint for failed result
+		$end_point = self::API_GROUP_IS_OWNER_ENDPOINT . '/' . $this->group->getId();
+		
+		$this->client->request('GET', $end_point, [], [], ['HTTP_Token' => $this->mobile1_token], $content);
+		
+		$request = $this->client->getRequest();
+		
+		$response = $this->client->getResponse();
+		
+		$content = json_decode($response->getContent());
+		
+		$this->assertNotEmpty($content, 'true');
+		
+		$this->assertEquals(
+				204,
+				$response->getStatusCode(),
+				'Should be a 204 response'
+				);
+		
+		$this->assertNotEmpty($response->headers->get('Access-Control-Allow-Origin'),
+				'Should return cors headers');
+	}
+}

--- a/backend/src/Civix/CoreBundle/Entity/Group.php
+++ b/backend/src/Civix/CoreBundle/Entity/Group.php
@@ -1256,7 +1256,7 @@ class Group implements UserInterface, EquatableInterface, \Serializable, Checkin
      */
     public function isOwner(User $user)
     {
-    	return $this->getOwner()->getId() === $user->getId();
+    	return !empty($this->getOwner()) && $this->getOwner()->getId() === $user->getId();
     }
     
     /**

--- a/backend/src/Civix/CoreBundle/Entity/Group.php
+++ b/backend/src/Civix/CoreBundle/Entity/Group.php
@@ -1206,7 +1206,7 @@ class Group implements UserInterface, EquatableInterface, \Serializable, Checkin
      *
      * @param \Civix\CoreBundle\Entity\UserGroupManager $manager
      */
-    public function removeUser(UserGroupManager $manager)
+    public function removeManager(UserGroupManager $manager)
     {
     	$this->managers->removeElement($manager);
     }
@@ -1216,7 +1216,7 @@ class Group implements UserInterface, EquatableInterface, \Serializable, Checkin
      *
      * @return \Doctrine\Common\Collections\Collection
      */
-    public function getUsers()
+    public function getManagers()
     {
     	return new ArrayCollection(array_map(
     			function ($usergroupmanager) {

--- a/backend/src/Civix/CoreBundle/Entity/Group.php
+++ b/backend/src/Civix/CoreBundle/Entity/Group.php
@@ -292,9 +292,18 @@ class Group implements UserInterface, EquatableInterface, \Serializable, Checkin
     private $joined;
 
     /**
+     * Group members
+     * 
      * @ORM\OneToMany(targetEntity="UserGroup", mappedBy="group")
      */
     private $users;
+    
+    /**
+     * Group managers (that are group members too)
+     *
+     * @ORM\OneToMany(targetEntity="UserGroupManager", mappedBy="group")
+     */
+    private $managers;
 
     /**
      * @ORM\ManyToMany(targetEntity="User", mappedBy="invites")
@@ -511,7 +520,8 @@ class Group implements UserInterface, EquatableInterface, \Serializable, Checkin
     public function init()
     {
         $this->salt = base_convert(sha1(uniqid(mt_rand(), true)), 16, 36);
-        $this->users = new \Doctrine\Common\Collections\ArrayCollection();
+        $this->users = new \Doctrine\Common\Collections\ArrayCollection(); // Group members
+        $this->managers = new \Doctrine\Common\Collections\ArrayCollection(); // Group managers (that are group members too)
         $this->invites = new \Doctrine\Common\Collections\ArrayCollection();
         $this->localRepresentatives = new \Doctrine\Common\Collections\ArrayCollection();
         $this->fields = new \Doctrine\Common\Collections\ArrayCollection();
@@ -1175,6 +1185,45 @@ class Group implements UserInterface, EquatableInterface, \Serializable, Checkin
             },
             $this->users->toArray()
         ));
+    }
+    
+    /**
+     * Add group manager users.
+     *
+     * @param \Civix\CoreBundle\Entity\UserGroupManager $manager
+     *
+     * @return Group
+     */
+    public function addManager(UserGroupManager $manager)
+    {
+    	$this->managers[] = $manager;
+    
+    	return $this;
+    }
+    
+    /**
+     * Remove group manager users.
+     *
+     * @param \Civix\CoreBundle\Entity\UserGroupManager $manager
+     */
+    public function removeUser(UserGroupManager $manager)
+    {
+    	$this->managers->removeElement($manager);
+    }
+    
+    /**
+     * Get users.
+     *
+     * @return \Doctrine\Common\Collections\Collection
+     */
+    public function getUsers()
+    {
+    	return new ArrayCollection(array_map(
+    			function ($usergroupmanager) {
+    				return $usergroupmanager->getUser();
+    			},
+    			$this->managers->toArray()
+    			));
     }
 
     /**

--- a/backend/src/Civix/CoreBundle/Entity/Group.php
+++ b/backend/src/Civix/CoreBundle/Entity/Group.php
@@ -1135,6 +1135,26 @@ class Group implements UserInterface, EquatableInterface, \Serializable, Checkin
     {
         return $user->getGroups()->contains($this) ? 1 : 0;
     }
+    
+    /**
+     * Checks if a user belongs as group member to the current group
+     *
+     * @return boolean
+     */
+    public function isMember(User $user)
+    {
+    	return $this->getUsers()->contains($user);
+    }
+    
+    /**
+     * Checks if a user belongs as group manager to the current group
+     *
+     * @return boolean
+     */
+    public function isManager(User $user)
+    {
+    	return $this->getManagers()->contains($user);
+    }
 
     public function getPicture()
     {

--- a/backend/src/Civix/CoreBundle/Entity/Group.php
+++ b/backend/src/Civix/CoreBundle/Entity/Group.php
@@ -1227,6 +1227,19 @@ class Group implements UserInterface, EquatableInterface, \Serializable, Checkin
     }
 
     /**
+     * Check if a User give is really the group owner for a 
+     * group
+     * 
+     * @param User $user
+     * 
+     * @return boolean
+     */
+    public function isOwner(User $user)
+    {
+    	return $this->getOwner()->getId() === $user->getId();
+    }
+    
+    /**
      * @return mixed
      */
     public function getOwner()

--- a/backend/src/Civix/CoreBundle/Entity/UserGroupManager.php
+++ b/backend/src/Civix/CoreBundle/Entity/UserGroupManager.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace Civix\CoreBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use JMS\Serializer\Annotation as Serializer;
+
+/**
+ * User group managers for a group.
+ *
+ * @ORM\Table(
+ *      name="users_groups_managers",
+ *      uniqueConstraints=
+ *      {
+ *          @ORM\UniqueConstraint(name="unique_user_group", columns={"user_id", "group_id"})
+ *      }
+ * )
+ * @ORM\Entity(repositoryClass="Civix\CoreBundle\Repository\UserGroupManagerRepository")
+ * @Serializer\ExclusionPolicy("all")
+ */
+class UserGroupManager
+{
+    const STATUS_PENDING = 0;
+    const STATUS_ACTIVE = 1;
+
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     * @Serializer\Expose()
+     * @Serializer\Groups({"api-info", "api-groups"})
+     */
+    protected $id;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="Civix\CoreBundle\Entity\User", inversedBy="groups", cascade={"persist"})
+     * @ORM\JoinColumn(name="user_id", referencedColumnName="id", onDelete="cascade")
+     * @Serializer\Expose()
+     */
+    private $user;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="Civix\CoreBundle\Entity\Group", inversedBy="users", cascade={"persist"})
+     * @ORM\JoinColumn(name="group_id", referencedColumnName="id", onDelete="cascade")
+     * @Serializer\Expose()
+     * @Serializer\Groups({"api-groups"})
+     */
+    private $group;
+
+    /**
+     * @var int
+     *
+     * @ORM\Column(name="group_id", type="integer", nullable=true)
+     */
+    private $group_id;
+
+    /**
+     * @var \DateTime created_at
+     *
+     * @ORM\Column(name="created_at", type="datetime")
+     */
+    private $createdAt;
+
+    /**
+     * @var int
+     *
+     * @ORM\Column(name="status", type="smallint")
+     * @Serializer\Expose()
+     * @Serializer\Groups({"api-info", "api-groups"})
+     */
+    private $status;
+
+    public function __construct(User $user, Group $group)
+    {
+        $this->setUser($user);
+        $this->setGroup($group);
+        $this->setCreatedAt(new \DateTime());
+
+        //set status according to membership control in group
+        if ($group->getMembershipControl() == Group::GROUP_MEMBERSHIP_APPROVAL) {
+            $this->setStatus(self::STATUS_PENDING);
+        } else {
+            $this->setStatus(self::STATUS_ACTIVE);
+        }
+    }
+
+    /**
+     * Get id.
+     *
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * Set status.
+     *
+     * @param int $status
+     *
+     * @return UserGroup
+     */
+    public function setStatus($status)
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+
+    /**
+     * Get status.
+     *
+     * @return int
+     */
+    public function getStatus()
+    {
+        return $this->status;
+    }
+
+    /**
+     * Set user.
+     *
+     * @param \Civix\CoreBundle\Entity\User $user
+     *
+     * @return UserGroup
+     */
+    public function setUser(\Civix\CoreBundle\Entity\User $user)
+    {
+        $this->user = $user;
+
+        return $this;
+    }
+
+    /**
+     * Get user.
+     *
+     * @return \Civix\CoreBundle\Entity\User
+     */
+    public function getUser()
+    {
+        return $this->user;
+    }
+
+    /**
+     * Set group.
+     *
+     * @param \Civix\CoreBundle\Entity\Group $group
+     *
+     * @return UserGroup
+     */
+    public function setGroup(\Civix\CoreBundle\Entity\Group $group)
+    {
+        $this->group = $group;
+
+        return $this;
+    }
+
+    /**
+     * Get group.
+     *
+     * @return \Civix\CoreBundle\Entity\Group
+     */
+    public function getGroup()
+    {
+        return $this->group;
+    }
+
+    /**
+     * @return int
+     */
+    public function getGroupId()
+    {
+        return $this->group_id;
+    }
+
+    /**
+     * @param int $group_id
+     *
+     * @return $this
+     */
+    public function setGroupId($group_id)
+    {
+        $this->group_id = $group_id;
+
+        return $this;
+    }
+
+    /**
+     * Set createAt.
+     *
+     * @param \DateTime $createdAt
+     *
+     * @return UserGroup
+     */
+    public function setCreatedAt($createdAt)
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    /**
+     * Get createAt.
+     *
+     * @return \DateTime
+     */
+    public function getCreatedAt()
+    {
+        return $this->createdAt;
+    }
+}

--- a/backend/src/Civix/CoreBundle/Repository/GroupRepository.php
+++ b/backend/src/Civix/CoreBundle/Repository/GroupRepository.php
@@ -11,6 +11,10 @@ use Symfony\Component\Security\Core\Util\SecureRandom;
 
 class GroupRepository extends EntityRepository
 {
+	/**
+	 * 
+	 * @param User $user
+	 */
     public function getGroupsByUser(User $user)
     {
         $queryBuilder = $this->getEntityManager()->createQueryBuilder();
@@ -22,6 +26,10 @@ class GroupRepository extends EntityRepository
                 ->getResult();
     }
 
+    /**
+     * 
+     * @param User $user
+     */
     public function getUserGroupsByUser(User $user)
     {
         $qb = $this->getEntityManager()->createQueryBuilder();
@@ -37,6 +45,10 @@ class GroupRepository extends EntityRepository
         ;
     }
 
+    /**
+     * 
+     * @param User $user
+     */
     public function getPopularGroupsByUser(User $user)
     {
         $groupOfUserIds = $user->getGroupsIds();
@@ -63,6 +75,13 @@ class GroupRepository extends EntityRepository
         return $qb->getQuery()->getResult();
     }
 
+    /**
+     * Fetch the groups of common type from 7 days ago to the current
+     * moment and check if the current user belongs in each groups
+     * for display as groups news results.
+     * 
+     * @param User $user
+     */
     public function getNewGroupsByUser(User $user)
     {
         $groupOfUserIds = $user->getGroupsIds();
@@ -91,6 +110,11 @@ class GroupRepository extends EntityRepository
         return $qb->getQuery()->getResult();
     }
 
+    /**
+     * 
+     * @param unknown $type
+     * @param string $order
+     */
     public function getQueryGroupOrderedById($type = Group::GROUP_TYPE_COMMON, $order = 'DESC')
     {
         return $this->createQueryBuilder('g')
@@ -99,6 +123,10 @@ class GroupRepository extends EntityRepository
                 ->orderBy('g.id', $order);
     }
 
+    /**
+     * 
+     * @param Group $countryGroup
+     */
     public function getQueryCountryGroupChildren(Group $countryGroup)
     {
         return $this->createQueryBuilder('g')
@@ -107,6 +135,10 @@ class GroupRepository extends EntityRepository
         ;
     }
 
+    /**
+     * 
+     * @param Group $group
+     */
     public function removeGroup(Group $group)
     {
         $this->getEntityManager()
@@ -139,6 +171,11 @@ class GroupRepository extends EntityRepository
             ->execute();
     }
 
+    /**
+     * 
+     * @param Group $group
+     * @return unknown
+     */
     public function getTotalMembers(Group $group)
     {
         $count = $this->getEntityManager()
@@ -156,6 +193,11 @@ class GroupRepository extends EntityRepository
         return $count;
     }
 
+    /**
+     * 
+     * @param unknown $id
+     * @param unknown $type
+     */
     public function getGroupByIdAndType($id, $type = Group::GROUP_TYPE_COMMON)
     {
         return $this->findOneBy(array(
@@ -164,6 +206,10 @@ class GroupRepository extends EntityRepository
         ));
     }
 
+    /**
+     * 
+     * @param unknown $state
+     */
     public function getLocalGroupsByState($state)
     {
         return $this->createQueryBuilder('g')
@@ -175,6 +221,11 @@ class GroupRepository extends EntityRepository
         ;
     }
 
+    /**
+     * 
+     * @param unknown $id
+     * @param unknown $representativeId
+     */
     public function getLocalGroupForRepr($id, $representativeId)
     {
         return $this->createQueryBuilder('gr')
@@ -191,6 +242,9 @@ class GroupRepository extends EntityRepository
             ->getOneOrNullResult();
     }
 
+    /**
+     * 
+     */
     public function cleanIncorrectLocalGroup()
     {
         return $this->getEntityManager()
@@ -200,6 +254,11 @@ class GroupRepository extends EntityRepository
             ->execute();
     }
 
+    /**
+     * 
+     * @param unknown $query
+     * @param User $user
+     */
     public function findByQuery($query, User $user)
     {
         $qb = $this->createQueryBuilder('g');
@@ -212,6 +271,9 @@ class GroupRepository extends EntityRepository
         return $qb->getQuery()->getResult();
     }
 
+    /**
+     * 
+     */
     public function cleanCommonGroups()
     {
         return $this->getEntityManager()
@@ -221,6 +283,10 @@ class GroupRepository extends EntityRepository
             ->execute();
     }
 
+    /**
+     * 
+     * @param unknown $country
+     */
     public function findCountryGroup($country)
     {
         return $this->findOneBy([
@@ -229,6 +295,11 @@ class GroupRepository extends EntityRepository
         ]);
     }
 
+    /**
+     * 
+     * @param unknown $state
+     * @param Group $countryGroup
+     */
     public function findStateGroup($state, Group $countryGroup = null)
     {
         return $this->findOneBy([
@@ -238,6 +309,11 @@ class GroupRepository extends EntityRepository
         ]);
     }
 
+    /**
+     * 
+     * @param unknown $location
+     * @param Group $stateGroup
+     */
     public function findLocalGroup($location, Group $stateGroup = null)
     {
         return $this->findOneBy([
@@ -247,6 +323,11 @@ class GroupRepository extends EntityRepository
         ]);
     }
 
+    /**
+     * 
+     * @param AddressComponent $addressComponent
+     * @return \Civix\CoreBundle\Entity\Group
+     */
     public function getCountryGroup(AddressComponent $addressComponent)
     {
         $group = $this->findCountryGroup($addressComponent->getShortName());
@@ -270,6 +351,12 @@ class GroupRepository extends EntityRepository
         return $group;
     }
 
+    /**
+     * 
+     * @param AddressComponent $addressComponent
+     * @param Group $countryGroup
+     * @return \Civix\CoreBundle\Entity\Group
+     */
     public function getStateGroup(AddressComponent $addressComponent, Group $countryGroup = null)
     {
         $group = $this->findStateGroup($addressComponent->getShortName(), $countryGroup);
@@ -292,7 +379,12 @@ class GroupRepository extends EntityRepository
 
         return $group;
     }
-
+    
+    /**
+     * 
+     * @param AddressComponent $addressComponent
+     * @param Group $stateGroup
+     */
     public function getLocalGroup(AddressComponent $addressComponent, Group $stateGroup = null)
     {
         $group = $this->findLocalGroup($addressComponent->getShortName(), $stateGroup);

--- a/backend/src/Civix/CoreBundle/Repository/UserGroupManagerRepository.php
+++ b/backend/src/Civix/CoreBundle/Repository/UserGroupManagerRepository.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Civix\CoreBundle\Repository;
+
+use Doctrine\ORM\EntityRepository;
+use Civix\CoreBundle\Entity\Group;
+use Civix\CoreBundle\Entity\User;
+use Civix\CoreBundle\Entity\UserGroup;
+
+class UserGroupManagerRepository extends EntityRepository
+{
+    public function getUsersByGroupQuery(Group $group, $status = null)
+    {
+        $query = $this->getEntityManager()->createQueryBuilder()
+            ->select('gu, gr')
+            ->from('CivixCoreBundle:UserGroupManager', 'gu')
+            ->leftJoin('gu.group', 'gr')
+            ->where('gu.group = :group')
+            ->setParameter('group', $group);
+
+        if (!is_null($status)) {
+            $query
+                ->andWhere('gu.status = :status')
+                ->setParameter('status', $status);
+        }
+        $query
+            ->orderBy('gu.createdAt', 'asc')
+            ->getQuery();
+
+        return $query;
+    }
+
+    public function setApprovedAllUsersInGroup(Group $group)
+    {
+        $this->getEntityManager()
+            ->createQuery('UPDATE CivixCoreBundle:UserGroupManager gu
+                              SET gu.status = :status
+                            WHERE gu.group = :group
+                              AND gu.status <> :status')
+            ->setParameter('status', UserGroup::STATUS_ACTIVE)
+            ->setParameter('group', $group)
+            ->execute();
+    }
+
+    /**
+     * @param Group $group
+     * @param User  $user
+     *
+     * @return UserGroup|null
+     *
+     * @throws \Doctrine\ORM\NonUniqueResultException
+     */
+    public function isJoinedUser(Group $group, User $user)
+    {
+        return $this->getEntityManager()->createQueryBuilder()
+                ->select('gu')
+                ->from('CivixCoreBundle:UserGroupManager', 'gu')
+                ->where('gu.user = :user')
+                ->andWhere('gu.group = :group')
+                ->setParameter('user', $user)
+                ->setParameter('group', $group)
+                ->getQuery()
+                ->getOneOrNullResult();
+    }
+
+    public function getSubQueryGroupByJoinStatus()
+    {
+        return $this->getEntityManager()->createQueryBuilder()
+            ->select('g')
+            ->from('CivixCoreBundle:Group', 'g')
+            ->innerJoin('g.users', 'gu')
+            ->where('gu.user = :user AND gu.status = :joinSubqueryStatus');
+    }
+
+    public function getActiveGroupIds(User $user)
+    {
+        $userGroups = $this->findBy([
+            'user' => $user,
+            'status' => UserGroup::STATUS_ACTIVE,
+        ]);
+
+        return array_map(function (UserGroup $userGroup) {
+            return $userGroup->getGroupId();
+        }, $userGroups);
+    }
+
+    public function getMembershipReportQuery(Group $group, $status = null)
+    {
+        $queryBuilder = $this->getEntityManager()->createQueryBuilder()
+            ->select('gu, gr, u')
+            ->addSelect('(SELECT gs.title FROM CivixCoreBundle:GroupSection gs LEFT JOIN gs.users us WHERE gs.group = gr AND us = u) as groupDivision')
+            ->from('CivixCoreBundle:UserGroup', 'gu')
+            ->leftJoin('gu.group', 'gr')
+            ->leftJoin('gu.user', 'u')
+            ->where('gu.group = :group')
+            ->setParameter('group', $group);
+
+        if (!is_null($status)) {
+            $queryBuilder
+                ->andWhere('gu.status = :status')
+                ->setParameter('status', $status);
+        }
+        $queryBuilder
+            ->orderBy('gu.createdAt', 'asc');
+
+        return $queryBuilder->getQuery();
+    }
+
+    public function getGeoUserGroups(User $user)
+    {
+        return $this->getEntityManager()->createQueryBuilder()
+            ->select('ug')
+            ->from(UserGroup::class, 'ug')
+            ->leftJoin('ug.group', 'g')
+            ->where('ug.user = :user AND g.groupType IN (:types)')
+            ->setParameter('user', $user)
+            ->setParameter('types', [Group::GROUP_TYPE_LOCAL, Group::GROUP_TYPE_STATE, Group::GROUP_TYPE_COUNTRY])
+            ->getQuery()->getResult();
+    }
+}


### PR DESCRIPTION
This is a work in progress for #23 allowing to add several group managers in a group.

This will be achieved adding a new reference in the group entity (managers) which is linked as OneToMany relation in user_groups_managers table, where we store which users are added as managers in a group. WIth this feature, we can have a list of group members (normal users) and a list of group managers (normal users that are also group members).

This will follow the spec:

1) Group has ONLY one user creator (which is a normal user).
2) Group could have 0 or a lot group managers (a group manager is just a normal user too).
3) Group could have 0 or a lot group members (a group member is just a normal user too).
4) The group creator could "promote" a group member to a group manager.
5) Only the group creator could assign privileges to group manager (no other group managers).
6) A group owns a plan (subscription level, entity Subscription) (free as default, but could be Silver, Gold, etc). Each group that a group creator contains could have different plan.
