### PR TITLE
Mark user test as "incomplete"

### DIFF
--- a/backend/src/Civix/ApiBundle/Tests/Controller/UserControllerTest.php
+++ b/backend/src/Civix/ApiBundle/Tests/Controller/UserControllerTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Civix\ApiBundle\Tests\Controller;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\Common\DataFixtures\Executor\AbstractExecutor;
 
 use Liip\FunctionalTestBundle\Test\WebTestCase;
 use Civix\CoreBundle\Tests\DataFixtures\ORM\LoadGroupData;
@@ -33,6 +33,12 @@ class UserControllerTest extends WebTestCase
 		// Creates a initial client
 		$this->client = NULL;
 	}
-	
-	// @todo Stub test for implement in future
+
+	/**
+	 * @todo Stub test for implement in future
+	 */
+	public function test()
+	{
+		$this->markTestIncomplete();
+	}
 }


### PR DESCRIPTION
To avoid a warning
No tests found in class "Civix\ApiBundle\Tests\Controller\UserControllerTest".