### PR TITLE
Revert "Skip slow unit test"

### DIFF
--- a/backend/src/Civix/CoreBundle/Tests/Command/CiceroSynchCommandTest.php
+++ b/backend/src/Civix/CoreBundle/Tests/Command/CiceroSynchCommandTest.php
@@ -31,8 +31,6 @@ class CiceroSynchCommandTest extends WebTestCase
      */
     public function testSynch()
     {
-    	$this->markTestSkipped('Too much time to run');
-    	
         $executor = $this->loadFixtures(array(
             'Civix\CoreBundle\Tests\DataFixtures\ORM\LoadDistrictData',
             'Civix\CoreBundle\Tests\DataFixtures\ORM\LoadSTRepresentativeData',
@@ -73,7 +71,6 @@ class CiceroSynchCommandTest extends WebTestCase
      */
     public function testSynchLink()
     {
-    	$this->markTestSkipped('Too much time to run');
         $executor = $this->loadFixtures(array(
             'Civix\CoreBundle\Tests\DataFixtures\ORM\LoadDistrictData',
             'Civix\CoreBundle\Tests\DataFixtures\ORM\LoadSTRepresentativeData',
@@ -133,8 +130,6 @@ class CiceroSynchCommandTest extends WebTestCase
      */
     public function testSynchWithChangedOfficialTitle()
     {
-    	$this->markTestSkipped('Too much time to run');
-    	
         $executor = $this->loadFixtures(array(
             'Civix\CoreBundle\Tests\DataFixtures\ORM\LoadDistrictData',
             'Civix\CoreBundle\Tests\DataFixtures\ORM\LoadSTRepresentativeData',
@@ -175,8 +170,6 @@ class CiceroSynchCommandTest extends WebTestCase
      */
     public function testSynchWithChangedOfficialTitleLink()
     {
-    	$this->markTestSkipped('Too much time to run');
-    	
         $executor = $this->loadFixtures(array(
             'Civix\CoreBundle\Tests\DataFixtures\ORM\LoadDistrictData',
             'Civix\CoreBundle\Tests\DataFixtures\ORM\LoadSTRepresentativeData',
@@ -224,8 +217,6 @@ class CiceroSynchCommandTest extends WebTestCase
      */
     public function testSynchWithChangedDistrict()
     {
-    	$this->markTestSkipped('Too much time to run');
-    	
         $executor = $this->loadFixtures(array(
             'Civix\CoreBundle\Tests\DataFixtures\ORM\LoadDistrictData',
             'Civix\CoreBundle\Tests\DataFixtures\ORM\LoadSTRepresentativeData',
@@ -266,8 +257,6 @@ class CiceroSynchCommandTest extends WebTestCase
      */
     public function testSynchWithChangedDistrictLink()
     {
-    	$this->markTestSkipped('Too much time to run');
-    	
         $executor = $this->loadFixtures(array(
             'Civix\CoreBundle\Tests\DataFixtures\ORM\LoadDistrictData',
             'Civix\CoreBundle\Tests\DataFixtures\ORM\LoadSTRepresentativeData',
@@ -311,8 +300,6 @@ class CiceroSynchCommandTest extends WebTestCase
      */
     public function testSynchRepresentativeNotFound()
     {
-    	$this->markTestSkipped('Too much time to run');
-    	
         $this->loadFixtures(array(
             'Civix\CoreBundle\Tests\DataFixtures\ORM\LoadDistrictData',
             'Civix\CoreBundle\Tests\DataFixtures\ORM\LoadSTRepresentativeData',
@@ -340,8 +327,6 @@ class CiceroSynchCommandTest extends WebTestCase
      */
     public function testSynchRepresentativeNotFoundLink()
     {
-    	$this->markTestSkipped('Too much time to run');
-    	
         $this->loadFixtures(array(
             'Civix\CoreBundle\Tests\DataFixtures\ORM\LoadDistrictData',
             'Civix\CoreBundle\Tests\DataFixtures\ORM\LoadSTRepresentativeData',

--- a/backend/src/Civix/CoreBundle/Tests/Repository/BookmarkRepositoryTest.php
+++ b/backend/src/Civix/CoreBundle/Tests/Repository/BookmarkRepositoryTest.php
@@ -33,8 +33,6 @@ class BookmarkRepositoryTest extends WebTestCase
      */
     public function setUp()
     {
-	return;
-
         /** @var AbstractExecutor $fixtures */
         $fixtures = $this->loadFixtures([LoadUserData::class]);
         $reference = $fixtures->getReferenceRepository();
@@ -51,8 +49,6 @@ class BookmarkRepositoryTest extends WebTestCase
 
     public function testSave()
     {
-	$this->markTestSkipped('Too much time to run');
-
         $this->assertNotEmpty($this->bookmark1->getId());
         $this->assertEquals($this->bookmark1->getId(), $this->bookmark2->getId());
         $this->assertNotEquals($this->bookmark1->getId(), $this->bookmark3->getId());
@@ -61,8 +57,6 @@ class BookmarkRepositoryTest extends WebTestCase
 
     public function testFindByType()
     {
-	$this->markTestSkipped('Too much time to run');
-
         $savedBookmarks1 = $this->repo->findByType(Bookmark::TYPE_ALL, $this->user, 1);
         $savedBookmarks2 = $this->repo->findByType(Bookmark::TYPE_POLL, $this->user, 1);
         $savedBookmarks3 = $this->repo->findByType(Bookmark::TYPE_PETITION, $this->user, 1);
@@ -74,8 +68,6 @@ class BookmarkRepositoryTest extends WebTestCase
 
     public function testDelete()
     {
-	$this->markTestSkipped('Too much time to run');
-
         $savedBookmarks = $this->repo->findByType(Bookmark::TYPE_ALL, $this->user, 1);
 
         $deleted = array();

--- a/backend/src/Civix/CoreBundle/Tests/Service/CiceroApiTest.php
+++ b/backend/src/Civix/CoreBundle/Tests/Service/CiceroApiTest.php
@@ -33,8 +33,6 @@ class CiceroApiTest extends WebTestCase
      */
     public function testGetRepresentativeByLocation()
     {
-    	$this->markTestSkipped('Too much time to run');
-    	
         $this->loadFixtures(array(
             'Civix\CoreBundle\Tests\DataFixtures\ORM\LoadDistrictData',
             'Civix\CoreBundle\Tests\DataFixtures\ORM\LoadInitRepresentativeData',
@@ -121,8 +119,6 @@ class CiceroApiTest extends WebTestCase
      */
     public function testUpdateByRepresentativeInfo()
     {
-    	$this->markTestSkipped('Too much time to run');
-    	
         $this->loadFixtures(array(
             'Civix\CoreBundle\Tests\DataFixtures\ORM\LoadDistrictData',
             'Civix\CoreBundle\Tests\DataFixtures\ORM\LoadInitRepresentativeData',


### PR DESCRIPTION
Reverts PowerlineApp/powerline-server#98

Not sure how you test it, but it really fast. No more than 10 sec to complete all test. Off course, there is lot of failing tests, but please don't mark it as skipped test with slow execution time because it make the code authors (especially me) confused. Or if you still get slow execution on this test, let me know your execution time instead.

Look [this one](https://github.com/PowerlineApp/powerline-server/pull/103#discussion_r58144839), maybe it will help speed up your test execution time.

```

PHPUnit 3.7.38 by Sebastian Bergmann.
Configuration read from /vagrant/backend/app/phpunit.xml
...F.......I....EEEEEEEE..I...................................... 65 / 72 ( 90%)

Time: 7.76 seconds, Memory: 112.50Mb

There were 10 errors:
...
...
```