### PR TITLE
Fix announcement fixtures

### DIFF
--- a/backend/src/Civix/CoreBundle/Tests/DataFixtures/ORM/LoadGroupAnnouncementData.php
+++ b/backend/src/Civix/CoreBundle/Tests/DataFixtures/ORM/LoadGroupAnnouncementData.php
@@ -19,21 +19,21 @@ class LoadGroupAnnouncementData extends AbstractFixture implements FixtureInterf
 
         $announcement = new GroupAnnouncement();
         $announcement->setUser($group);
-        $announcement->setContent($faker->text);
+        $announcement->setContent($faker->sentence);
         $this->addReference('announcement_group_1', $announcement);
         $manager->persist($announcement);
 
         //published
         $announcementPublished = new GroupAnnouncement();
         $announcementPublished->setUser($group);
-        $announcementPublished->setContent($faker->text);
+        $announcementPublished->setContent($faker->sentence);
         $announcementPublished->setPublishedAt(new \DateTime('-1 month'));
         $this->addReference('announcement_group_2', $announcementPublished);
         $manager->persist($announcementPublished);
 
         $announcementPublished = new GroupAnnouncement();
         $announcementPublished->setUser($group);
-        $announcementPublished->setContent($faker->text);
+        $announcementPublished->setContent($faker->sentence);
         $announcementPublished->setPublishedAt(new \DateTime());
         $this->addReference('announcement_group_3', $announcementPublished);
         $manager->persist($announcementPublished);
@@ -42,7 +42,7 @@ class LoadGroupAnnouncementData extends AbstractFixture implements FixtureInterf
 
         $announcement = new GroupAnnouncement();
         $announcement->setUser($group);
-        $announcement->setContent($faker->text);
+        $announcement->setContent($faker->sentence);
         $announcement->setPublishedAt(new \DateTime());
         $this->addReference('announcement_private_1', $announcement);
         $manager->persist($announcement);
@@ -51,13 +51,13 @@ class LoadGroupAnnouncementData extends AbstractFixture implements FixtureInterf
 
         $announcement = new GroupAnnouncement();
         $announcement->setUser($group);
-        $announcement->setContent($faker->text);
+        $announcement->setContent($faker->sentence);
         $this->addReference('announcement_secret_1', $announcement);
         $manager->persist($announcement);
 
         $announcementPublished = new GroupAnnouncement();
         $announcementPublished->setUser($group);
-        $announcementPublished->setContent($faker->text);
+        $announcementPublished->setContent($faker->sentence);
         $announcementPublished->setPublishedAt(new \DateTime());
         $this->addReference('announcement_secret_2', $announcementPublished);
         $manager->persist($announcementPublished);
@@ -66,7 +66,7 @@ class LoadGroupAnnouncementData extends AbstractFixture implements FixtureInterf
 
         $announcement = new GroupAnnouncement();
         $announcement->setUser($group);
-        $announcement->setContent($faker->text);
+        $announcement->setContent($faker->sentence);
         $this->addReference('announcement_topsecret_1', $announcement);
         $manager->persist($announcement);
 

--- a/backend/src/Civix/CoreBundle/Tests/DataFixtures/ORM/LoadRepresentativeAnnouncementData.php
+++ b/backend/src/Civix/CoreBundle/Tests/DataFixtures/ORM/LoadRepresentativeAnnouncementData.php
@@ -19,21 +19,21 @@ class LoadRepresentativeAnnouncementData extends AbstractFixture implements Fixt
 
         $announcement = new RepresentativeAnnouncement();
         $announcement->setUser($representative);
-        $announcement->setContent($faker->text);
+        $announcement->setContent($faker->sentence);
         $this->addReference('announcement_jb_1', $announcement);
         $manager->persist($announcement);
 
         //published
         $announcementPublished = new RepresentativeAnnouncement();
         $announcementPublished->setUser($representative);
-        $announcementPublished->setContent($faker->text);
+        $announcementPublished->setContent($faker->sentence);
         $announcementPublished->setPublishedAt(new \DateTime('-1 month'));
         $this->addReference('announcement_jb_2', $announcementPublished);
         $manager->persist($announcementPublished);
 
         $announcementPublished = new RepresentativeAnnouncement();
         $announcementPublished->setUser($representative);
-        $announcementPublished->setContent($faker->text);
+        $announcementPublished->setContent($faker->sentence);
         $announcementPublished->setPublishedAt(new \DateTime());
         $this->addReference('announcement_jb_3', $announcementPublished);
         $manager->persist($announcementPublished);
@@ -42,7 +42,7 @@ class LoadRepresentativeAnnouncementData extends AbstractFixture implements Fixt
 
         $announcement = new RepresentativeAnnouncement();
         $announcement->setUser($representative);
-        $announcement->setContent($faker->text);
+        $announcement->setContent($faker->sentence);
         $this->addReference('announcement_jt_1', $announcement);
         $manager->persist($announcement);
 
@@ -50,7 +50,7 @@ class LoadRepresentativeAnnouncementData extends AbstractFixture implements Fixt
 
         $announcement = new RepresentativeAnnouncement();
         $announcement->setUser($representative);
-        $announcement->setContent($faker->text);
+        $announcement->setContent($faker->sentence);
         $announcement->setPublishedAt(new \DateTime());
         $this->addReference('announcement_wc_1', $announcement);
         $manager->persist($announcement);


### PR DESCRIPTION
Replace Faker->text with Faker->sentence to avoid error with deleted line breaks in parsed_content attribute