### PR TITLE
Add command to fix local user's groups

### DIFF
--- a/backend/src/Civix/CoreBundle/Command/FixLocalUserGroupsCommand.php
+++ b/backend/src/Civix/CoreBundle/Command/FixLocalUserGroupsCommand.php
@@ -1,0 +1,29 @@
+<?php
+namespace Civix\CoreBundle\Command;
+
+use Civix\CoreBundle\Entity\User;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class FixLocalUserGroupsCommand extends ContainerAwareCommand
+{
+    protected function configure()
+    {
+        $this->setName('fix-local-user-groups');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $users = $this->getContainer()->get('doctrine')
+            ->getRepository(User::class)
+            ->createQueryBuilder('u')
+            ->getQuery()->iterate();
+        $groupManager = $this->getContainer()->get('civix_core.group_manager');
+        foreach ($users as $user) {
+            /** @var User[] $user */
+            $output->writeln('Processing user #'.$user[0]->getId());
+            $groupManager->autoJoinUser($user[0]);
+        }
+    }
+}


### PR DESCRIPTION
After deploy need to run `app/console fix-local-user-groups` and check that all users have local groups.