### PR TITLE
Move Nelmio api doc bundle to prod config

### DIFF
--- a/backend/app/AppKernel.php
+++ b/backend/app/AppKernel.php
@@ -34,6 +34,7 @@ class AppKernel extends Kernel
             new Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle(),
             new FOS\RestBundle\FOSRestBundle(),
             new HWI\Bundle\OAuthBundle\HWIOAuthBundle(),
+            new Nelmio\ApiDocBundle\NelmioApiDocBundle(),
 
             new Civix\FrontBundle\CivixFrontBundle(),
             new Civix\CoreBundle\CivixCoreBundle(),
@@ -44,7 +45,6 @@ class AppKernel extends Kernel
 
             $bundles[] = new Sensio\Bundle\DistributionBundle\SensioDistributionBundle();
             $bundles[] = new Sensio\Bundle\GeneratorBundle\SensioGeneratorBundle();
-            $bundles[] = new Nelmio\ApiDocBundle\NelmioApiDocBundle();
             $bundles[] = new Civix\LoadBundle\CivixLoadBundle();
         }
 

--- a/backend/app/config/config.yml
+++ b/backend/app/config/config.yml
@@ -260,3 +260,6 @@ hwi_oauth:
 
 monolog:
     channels: ['push']
+
+nelmio_api_doc:
+    name: Civix API documentation

--- a/backend/app/config/config_dev.yml
+++ b/backend/app/config/config_dev.yml
@@ -32,8 +32,5 @@ monolog:
 assetic:
     use_controller: false
 
-nelmio_api_doc:
-    name: Civix API documentation
-
 #swiftmailer:
 #    delivery_address: me@example.com

--- a/backend/app/config/routing.yml
+++ b/backend/app/config/routing.yml
@@ -75,4 +75,14 @@ civix_superuser:
 civix_account:
     resource: "@CivixFrontBundle/Controller/AccountController.php"
     prefix:   /account
-    type: annotation 
+    type: annotation
+
+NelmioApiDocBundle:
+    resource: "@NelmioApiDocBundle/Resources/config/routing.yml"
+    prefix:   /api-doc
+    defaults: { view: default }
+
+NelmioSwaggerApiDocBundle:
+    resource: "@NelmioApiDocBundle/Resources/config/swagger_routing.yml"
+    prefix:   /swagger
+    defaults: { view: default }

--- a/backend/app/config/routing_dev.yml
+++ b/backend/app/config/routing_dev.yml
@@ -4,13 +4,3 @@ _configurator:
 
 _main:
     resource: routing.yml
-
-NelmioApiDocBundle:
-    resource: "@NelmioApiDocBundle/Resources/config/routing.yml"
-    prefix:   /api-doc
-    defaults: { view: default }
-
-NelmioSwaggerApiDocBundle:
-    resource: "@NelmioApiDocBundle/Resources/config/swagger_routing.yml"
-    prefix:   /swagger
-    defaults: { view: default }


### PR DESCRIPTION
```
Uncaught PHP Exception Symfony\Component\OptionsResolver\Exception\InvalidOptionsException: "The option "description" does not exist. Known options are: "action", "attr", "auto_initialize", "block_name", "by_reference", "cascade_validation", "compound", "constraints", "csrf_field_name", "csrf_message", "csrf_protection", "csrf_provider", "data", "data_class", "disabled", "empty_data", "error_bubbling", "error_delay", "error_mapping", "error_type", "errors_on_forms", "extra_fields_message", "help_block", "help_inline", "help_label", "help_label_popover", "help_label_tooltip", "inherit_data", "intention", "invalid_message", "invalid_message_parameters", "label", "label_attr", "label_render", "mapped", "max_length", "method", "omit_collection_item", "pattern", "post_max_size_message", "property_path", "read_only", "render_fieldset", "render_optional_text", "render_required_asterisk", "required", "show_child_legend", "show_legend", "tabs_class", "translation_domain", "trim", "validation_groups", "virtual", "widget_add_btn", "widget_addon", "widget_checkbox_label", "widget_control_group", "widget_control_group_attr", "widget_controls", "widget_controls_attr", "widget_items_attr", "widget_prefix", "widget_remove_btn", "widget_suffix", "widget_type"" at /srv/civix/vendor/symfony/symfony/src/Symfony/Component/OptionsResolver/OptionsResolver.php line 255
```