### PR TITLE
Fix state's page in admin

### DIFF
--- a/backend/src/Civix/CoreBundle/Repository/StatesRepository.php
+++ b/backend/src/Civix/CoreBundle/Repository/StatesRepository.php
@@ -9,13 +9,13 @@ class StatesRepository extends EntityRepository
     public function getStatesWithSTRepresentative()
     {
         return $this->getEntityManager()
+            ->getConnection()
             ->createQueryBuilder()
-            ->select('st, COUNT(rs) AS stcount, MIN(rs.updatedAt) as lastUpdatedAt')
-            ->from('CivixCoreBundle:State', 'st')
-            ->leftJoin('st.stRepresentatives', 'rs')
-            ->groupBy('st.code, rs.state')
+            ->select('st.code, COUNT(rs.id) AS stcount, MIN(rs.updated_at) as lastUpdatedAt')
+            ->from('states', 'st')
+            ->leftJoin('st', 'cicero_representatives', 'rs', 'rs.state = st.code')
+            ->groupBy('st.code')
             ->orderBy('lastUpdatedAt', 'DESC')
-            ->addOrderBy('st.code', 'ASC')
-            ->getQuery();
+            ->addOrderBy('st.code', 'ASC');
     }
 }

--- a/backend/src/Civix/FrontBundle/Resources/views/Superuser/statesSettings.html.twig
+++ b/backend/src/Civix/FrontBundle/Resources/views/Superuser/statesSettings.html.twig
@@ -24,13 +24,13 @@
                 <tbody>
                     {% for stateRecord in pagination %}
                     <tr>
-                        <td>{{ stateRecord[0].code }}</td>
+                        <td>{{ stateRecord.code }}</td>
                         <td>{{ stateRecord.stcount }}</td>
                         <td>{{ stateRecord.lastUpdatedAt }}</td>
                         <td class="table-options">
                            {% if  stateRecord.stcount>0 %}
-                           <form class="form-link" action="{{ path('civix_front_superuser_settings_states_update', {'state': stateRecord[0].code}) }}" method="POST">
-                                <input type="hidden" name="_token" value="{{ csrf_token('state_repr_update_' ~ stateRecord[0].code) }}">
+                           <form class="form-link" action="{{ path('civix_front_superuser_settings_states_update', {'state': stateRecord.code}) }}" method="POST">
+                                <input type="hidden" name="_token" value="{{ csrf_token('state_repr_update_' ~ stateRecord.code) }}">
                                 <button type="submit" class="btn btn-link">Update</button>
                            </form>
                            {% else %}


### PR DESCRIPTION
```
Uncaught PHP Exception Doctrine\ORM\Query\QueryException: "[Semantical Error] line 0, col 129 near 'rs GROUP BY st.code,': Error: Class Civix\CoreBundle\Entity\State has no association named stRepresentatives" at /srv/civix/vendor/doctrine/orm/lib/Doctrine/ORM/Query/QueryException.php line 49
```