### PR TITLE
Sql errors

### DIFF
--- a/backend/src/Civix/CoreBundle/Repository/ActivityRepository.php
+++ b/backend/src/Civix/CoreBundle/Repository/ActivityRepository.php
@@ -274,10 +274,11 @@ class ActivityRepository extends EntityRepository
                     )
                 )
             )
-            WHERE question_id = :question'
+            WHERE question_id = :question',
+            [':question' => $question->getId()]
         );
 
-        return $query->execute([':question' => $question->getId()]);
+        return $query->execute();
     }
 
     public function updateResponseCountUserPetition(UserPetition $petition)
@@ -301,10 +302,11 @@ class ActivityRepository extends EntityRepository
                     )
                 )
             )
-            WHERE petition_id = :petition'
+            WHERE petition_id = :petition',
+            [':petition' => $petition->getId()]
         );
 
-        return $query->execute([':petition' => $petition->getId()]);
+        return $query->execute();
     }
 
     public function updateResponseCountPost(Post $post)
@@ -328,10 +330,11 @@ class ActivityRepository extends EntityRepository
                     )
                 )
             )
-            WHERE post_id = :post"
+            WHERE post_id = :post",
+            [':post' => $post->getId()]
         );
 
-        return $query->execute([':post' => $post->getId()]);
+        return $query->execute();
     }
 
     public function getActivitiesByGroupId($groupId, $maxResults = 500)

--- a/backend/src/Civix/CoreBundle/Repository/Report/MembershipReportRepository.php
+++ b/backend/src/Civix/CoreBundle/Repository/Report/MembershipReportRepository.php
@@ -25,7 +25,7 @@ class MembershipReportRepository extends EntityRepository
                     VALUES (
                         :user,
                         :group,
-                        COALESCE(:fields, (SELECT group_fields FROM membership_report WHERE user_id = :user AND group_id = :group), '{}')
+                        COALESCE(:fields, (SELECT group_fields FROM (SELECT group_fields FROM membership_report WHERE user_id = :user AND group_id = :group) AS temp), '{}')
                     )
                 ", [
                 ':user' => $user->getId(),


### PR DESCRIPTION
Uncaught PHP Exception Doctrine\DBAL\Exception\DriverException: "An exception occurred while executing '                     REPLACE INTO membership_report(user_id, group_id, group_fields)                      VALUES (                         ?,                         ?,                         COALESCE(?, (SELECT group_fields FROM membership_report WHERE user_id = ? AND group_id = ?), '{}')                     )                 ' with params [130, 415, null, 130, 415]:  SQLSTATE[HY000]: General error: 1093 You can't specify target table 'membership_report' for update in FROM clause" at /srv/civix/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php line 115 {"exception":"[object] (Doctrine\\DBAL\\Exception\\DriverException(code: 0): An exception occurred while executing '\n                    REPLACE INTO membership_report(user_id, group_id, group_fields) \n                    VALUES (\n                        ?,\n                        ?,\n                        COALESCE(?, (SELECT group_fields FROM membership_report WHERE user_id = ? AND group_id = ?), '{}')\n                    )\n                ' with params [130, 415, null, 130, 415]:\n\nSQLSTATE[HY000]: General error: 1093 You can't specify target table 'membership_report' for update in FROM clause at /srv/civix/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php:115, Doctrine\\DBAL\\Driver\\PDOException(code: HY000): SQLSTATE[HY000]: General error: 1093 You can't specify target table 'membership_report' for update in FROM clause at /srv/civix/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOStatement.php:93, PDOException(code: HY000): SQLSTATE[HY000]: General error: 1093 You can't specify target table 'membership_report' for update in FROM clause at /srv/civix/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOStatement.php:91)"} []