### PR TITLE
Fix error with empty discount code

### DIFF
--- a/backend/app/DoctrineMigrations/Version20170331041340.php
+++ b/backend/app/DoctrineMigrations/Version20170331041340.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20170331041340 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE discount_codes CHANGE original_code original_code VARCHAR(255) NOT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE discount_codes CHANGE original_code original_code VARCHAR(255) DEFAULT NULL COLLATE utf8mb4_unicode_ci');
+    }
+}

--- a/backend/src/Civix/CoreBundle/Entity/DiscountCode.php
+++ b/backend/src/Civix/CoreBundle/Entity/DiscountCode.php
@@ -34,7 +34,7 @@ class DiscountCode
     /**
      * @var string
      *
-     * @ORM\Column(name="original_code", type="string", nullable=true)
+     * @ORM\Column(name="original_code", type="string")
      */
     private $originalCode;
 
@@ -62,8 +62,11 @@ class DiscountCode
      */
     private $createdAt;
 
-    public function __construct($originalCode = null, User $owner = null)
+    public function __construct($originalCode, User $owner = null)
     {
+        if (!$originalCode) {
+            throw new \LogicException('Original code can not be blank');
+        }
         $this->code = $this->getRandomCode();
         $this->originalCode = $originalCode;
         $this->owner = $owner;

--- a/backend/src/Civix/CoreBundle/Model/Coupon.php
+++ b/backend/src/Civix/CoreBundle/Model/Coupon.php
@@ -29,7 +29,7 @@ class Coupon
         if ($this->discountCode instanceof DiscountCode) {
             return $this->discountCode->getOriginalCode();
         } else {
-            return (string)$this->discountCode;
+            return $this->discountCode ? (string)$this->discountCode : null;
         }
     }
 

--- a/backend/src/Civix/CoreBundle/Tests/Entity/DiscountCodeTest.php
+++ b/backend/src/Civix/CoreBundle/Tests/Entity/DiscountCodeTest.php
@@ -8,7 +8,7 @@ class DiscountCodeTest extends \PHPUnit_Framework_TestCase
 {
     public function testCodeGeneration()
     {
-        $code = new DiscountCode();
+        $code = new DiscountCode('XXX');
         $this->assertRegExp('/^[A-Z0-9]{12}$/', $code->getCode());
     }
 }


### PR DESCRIPTION
https://github.com/PowerlineApp/powerline-mobile/issues/498

InvalidArgumentException: "You cannot set 'coupon'to an empty string. We interpret empty strings as NULL in requests. You may set obj->coupon = NULL to delete the property"