### PR TITLE
Fix the type hint bug

### DIFF
--- a/backend/src/Civix/ApiBundle/Form/Type/CreateCommentType.php
+++ b/backend/src/Civix/ApiBundle/Form/Type/CreateCommentType.php
@@ -29,13 +29,13 @@ class CreateCommentType extends AbstractType
                     return $value->getId();
                 }
 
-                return $value;
+                return null;
             }, function ($value) use ($options) {
                 if ($value) {
                     return $options['em']->getRepository($options['data_class'])->find($value);
                 }
 
-                return $value;
+                return null;
             }
         ));
     }


### PR DESCRIPTION
request.CRITICAL: Uncaught PHP Exception Symfony\Component\PropertyAccess\Exception\InvalidArgumentException: "Expected argument of type "Civix\CoreBundle\Entity\BaseComment", "integer" given" at /srv/civix/vendor/symfony/symfony/src/Symfony/Component/PropertyAccess/PropertyAccessor.php line 275 {"exception":"[object] (Symfony\\Component\\PropertyAccess\\Exception\\InvalidArgumentException(code: 0): Expected argument of type \"Civix\\CoreBundle\\Entity\\BaseComment\", \"integer\" given at /srv/civix/vendor/symfony/symfony/src/Symfony/Component/PropertyAccess/PropertyAccessor.php:275)"} []