### PR TITLE
Skip an error if an email list is not found on removing

### DIFF
--- a/backend/src/Civix/CoreBundle/Service/Mailgun/MailgunApi.php
+++ b/backend/src/Civix/CoreBundle/Service/Mailgun/MailgunApi.php
@@ -101,6 +101,10 @@ class MailgunApi
         $listMember = $address;
         try {
             $this->client->delete("lists/$listAddress/members/$listMember");
+        } catch (MissingEndpoint $e) {
+            // if a mailing list doesn't exist - skip removing
+            $this->logger->info($e->getMessage(), ['address' => $listAddress, 'member' => $listMember]);
+            return true;
         } catch (\Exception $e) {
             $this->logError($e, __METHOD__, ['address' => $listAddress, 'member' => $listMember]);
             return false;


### PR DESCRIPTION
app.CRITICAL: Mailgun error in method Civix\CoreBundle\Service\Mailgun\MailgunApi::listRemoveMemberAction: The endpoint you've tried to access does not exist. Check your URL. 

request.CRITICAL: Uncaught PHP Exception Civix\CoreBundle\Exception\MailgunException: "An error has occurred in onUserBeforeUnjoin" at /srv/civix/src/Civix/CoreBundle/EventListener/MailgunSubscriber.php line 120 