### PR TITLE
Fix the issue with @everyone mention in post's body

### DIFF
--- a/backend/src/Civix/CoreBundle/EventListener/MentionSubscriber.php
+++ b/backend/src/Civix/CoreBundle/EventListener/MentionSubscriber.php
@@ -47,6 +47,9 @@ class MentionSubscriber implements EventSubscriber
                 $username = $matches[1];
                 if ($username === 'everyone'
                     && $entity instanceof BaseComment
+                    // check if it's not an auto comment (user == null)
+                    // @todo delete this check after getting rid of auto comments
+                    && $entity->getUser()
                     && method_exists($entity->getCommentedEntity(), 'getGroup')
                 ) {
                     /** @var Group $group */


### PR DESCRIPTION
Uncaught PHP Exception Symfony\Component\Debug\Exception\FatalThrowableError: "Type error: Argument 1 passed to Civix\CoreBundle\Entity\Group::isOwner() must implement interface Civix\CoreBundle\Entity\UserInterface, null given, called in /srv/civix/src/Civix/CoreBundle/EventListener/MentionSubscriber.php on line 55" at /srv/civix/src/Civix/CoreBundle/Entity/Group.php line 1083