### PR TITLE
Fix error Coupon::getCode() must be of the type string, null returned

### DIFF
--- a/backend/src/Civix/CoreBundle/Model/Coupon.php
+++ b/backend/src/Civix/CoreBundle/Model/Coupon.php
@@ -24,7 +24,7 @@ class Coupon
         return $this->discountCode;
     }
 
-    public function getCode(): string
+    public function getCode()
     {
         if ($this->discountCode instanceof DiscountCode) {
             return $this->discountCode->getOriginalCode();


### PR DESCRIPTION
Uncaught PHP Exception Symfony\Component\Debug\Exception\FatalThrowableError: "Type error: Return value of Civix\CoreBundle\Model\Coupon::getCode() must be of the type string, null returned" at /srv/civix/src/Civix/CoreBundle/Model/Coupon.php line 32