### PR TITLE
Forbid to rate root auto comments

### DIFF
--- a/backend/src/Civix/ApiBundle/Controller/V2/PollCommentController.php
+++ b/backend/src/Civix/ApiBundle/Controller/V2/PollCommentController.php
@@ -102,7 +102,7 @@ class PollCommentController extends AbstractCommentController
      * @Route("/rate", requirements={"id"="\d+"})
      * @Method("POST")
      *
-     * @ParamConverter("comment", class="Civix\CoreBundle\Entity\Poll\Comment")
+     * @ParamConverter("comment", class="Civix\CoreBundle\Entity\Poll\Comment", options={"repository_method" = "findOneForRate"})
      * @ParamConverter("rate",
      *     class="Civix\CoreBundle\Entity\Poll\CommentRate",
      *     options={"mapping" = {"comment" = "comment", "loggedInUser" = "user"}},

--- a/backend/src/Civix/ApiBundle/Controller/V2/PostCommentController.php
+++ b/backend/src/Civix/ApiBundle/Controller/V2/PostCommentController.php
@@ -103,7 +103,7 @@ class PostCommentController extends AbstractCommentController
      * @Route("/rate", requirements={"id"="\d+"})
      * @Method("POST")
      *
-     * @ParamConverter("comment", class="Civix\CoreBundle\Entity\Post\Comment")
+     * @ParamConverter("comment", class="Civix\CoreBundle\Entity\Post\Comment", options={"repository_method" = "findOneForRate"})
      * @ParamConverter("rate",
      *     class="Civix\CoreBundle\Entity\Post\CommentRate",
      *     options={"mapping" = {"comment" = "comment", "loggedInUser" = "user"}},

--- a/backend/src/Civix/ApiBundle/Controller/V2/UserPetitionCommentController.php
+++ b/backend/src/Civix/ApiBundle/Controller/V2/UserPetitionCommentController.php
@@ -102,7 +102,7 @@ class UserPetitionCommentController extends AbstractCommentController
      * @Route("/rate", requirements={"id"="\d+"})
      * @Method("POST")
      *
-     * @ParamConverter("comment", class="Civix\CoreBundle\Entity\UserPetition\Comment")
+     * @ParamConverter("comment", class="Civix\CoreBundle\Entity\UserPetition\Comment", options={"repository_method" = "findOneForRate"})
      * @ParamConverter("rate",
      *     class="Civix\CoreBundle\Entity\UserPetition\CommentRate",
      *     options={"mapping" = {"comment" = "comment", "loggedInUser" = "user"}},

--- a/backend/src/Civix/CoreBundle/Repository/CommentRepository.php
+++ b/backend/src/Civix/CoreBundle/Repository/CommentRepository.php
@@ -76,4 +76,14 @@ abstract class CommentRepository extends EntityRepository
 
         return $qb->getQuery();
     }
+
+    public function findOneForRate($id)
+    {
+        return $this->createQueryBuilder('c')
+            ->where('c.id = :id')
+            ->setParameter(':id', $id)
+            ->andWhere('c.user IS NOT NULL')
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
 }


### PR DESCRIPTION
Uncaught PHP Exception Symfony\Component\Debug\Exception\FatalThrowableError: "Type error: Argument 1 passed to Civix\CoreBundle\Entity\Karma::__construct() must be an instance of Civix\CoreBundle\Entity\User, null given, called in src/Civix/CoreBundle/EventListener/KarmaSubscriber.php on line 163" at src/Civix/CoreBundle/Entity/Karma.php line 95