### PR TITLE
Fix double execution after call of executeQuery for report repositories

### DIFF
--- a/backend/src/Civix/CoreBundle/Repository/Report/MembershipReportRepository.php
+++ b/backend/src/Civix/CoreBundle/Repository/Report/MembershipReportRepository.php
@@ -32,13 +32,15 @@ class MembershipReportRepository extends EntityRepository
                 ':group' => $group->getId(),
                 ':fields' => $groupFields ? json_encode($groupFields) : null,
             ])
-            ->execute();
+            ->rowCount();
     }
 
     public function deleteMembershipReport(User $user, Group $group)
     {
         return $this->getEntityManager()->getConnection()
-            ->executeQuery('DELETE FROM membership_report WHERE user_id = ? AND group_id = ?')
-            ->execute([$user->getId(), $group->getId()]);
+            ->delete('membership_report', [
+                'user_id' => $user->getId(),
+                'group_id' => $group->getId(),
+            ]);
     }
 }

--- a/backend/src/Civix/CoreBundle/Repository/Report/PostResponseRepository.php
+++ b/backend/src/Civix/CoreBundle/Repository/Report/PostResponseRepository.php
@@ -33,7 +33,7 @@ class PostResponseRepository extends EntityRepository
                 ':post' => $vote->getPost()->getId(),
                 ':vote' => $vote->getOptionTitle(),
             ]
-        )->execute();
+        )->rowCount();
     }
 
     public function deletePostResponseReport(Post\Vote $vote)

--- a/backend/src/Civix/CoreBundle/Repository/Report/UserReportRepository.php
+++ b/backend/src/Civix/CoreBundle/Repository/Report/UserReportRepository.php
@@ -48,7 +48,7 @@ class UserReportRepository extends EntityRepository
                     ':locality' => $locality,
                     ':districts' => $districts ? json_encode($districts) : null,
             ])
-            ->execute();
+            ->rowCount();
     }
 
     public function updateUserReportKarma(User $user)


### PR DESCRIPTION
Uncaught PHP Exception Doctrine\DBAL\Exception\SyntaxErrorException: "An exception occurred while executing 'DELETE FROM membership_report WHERE user_id = ? AND group_id = ?':

SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '? AND group_id = ?' at line 1" at vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php line 90