### PR TITLE
Add country validator for User entity

### DIFF
--- a/backend/src/Civix/ApiBundle/Tests/Controller/ProfileControllerTest.php
+++ b/backend/src/Civix/ApiBundle/Tests/Controller/ProfileControllerTest.php
@@ -46,7 +46,7 @@ class ProfileControllerTest extends WebTestCase
             'address2' => 'new-address2',
             'city' => 'new-city',
             'state' => 'new-state',
-            'country' => 'new-country',
+            'country' => 'DZ',
             'phone' => 'new-phone',
             'facebook_link' => 'new-facebookLink',
             'twitter_link' => 'new-twitterLink',
@@ -106,7 +106,7 @@ class ProfileControllerTest extends WebTestCase
             'address2' => 'new-address2',
             'city' => 'new-city',
             'state' => 'new-state',
-            'country' => 'new-country',
+            'country' => 'AO',
             'phone' => 'new-phone',
             'facebook_link' => 'new-facebookLink',
             'twitter_link' => 'new-twitterLink',
@@ -163,6 +163,7 @@ class ProfileControllerTest extends WebTestCase
             'last_name' => '',
             'email' => 'user2@example.com',
             'zip' => '',
+            'country' => 'United States',
         ];
         $client = $this->client;
 		$client->request('POST', self::API_ENDPOINT.'update', [], [], ['HTTP_Authorization' => 'Bearer type="user" token="user1"'], json_encode($params));
@@ -171,7 +172,7 @@ class ProfileControllerTest extends WebTestCase
         $data = json_decode($response->getContent(), true);
         /** @var array $errors */
         $errors = $data['errors'];
-        $this->assertCount(4, $errors);
+        $this->assertCount(5, $errors);
         foreach ($errors as $error) {
             switch ($error['property']) {
                 case 'first_name':
@@ -185,6 +186,9 @@ class ProfileControllerTest extends WebTestCase
                     break;
                 case 'email':
                     $message = 'This value is already used.';
+                    break;
+                case 'country':
+                    $message = 'This value is not a valid country.';
                     break;
                 default:
                     $this->fail("Property {$error['property']} should not have an error");

--- a/backend/src/Civix/CoreBundle/Entity/User.php
+++ b/backend/src/Civix/CoreBundle/Entity/User.php
@@ -205,6 +205,7 @@ class User implements
      * @ORM\Column(name="country", type="string", length=255, nullable=true)
      * @Serializer\Expose()
      * @Serializer\Groups({"api-profile", "api-info", "api-full-info", "api-leader-answers"})
+     * @Assert\Country(groups={"registration", "profile"})
      */
     private $country;
 

--- a/backend/tests/Civix/ApiBundle/Controller/SecureControllerTest.php
+++ b/backend/tests/Civix/ApiBundle/Controller/SecureControllerTest.php
@@ -84,6 +84,7 @@ class SecureControllerTest extends WebTestCase
      */
 	public function testRegistrationWithDuplicateDataReturnsErrors(): void
     {
+        $this->loadFixtures([LoadUserData::class]);
         $parameters = $this->getParameters();
         $client = $this->makeClient(false, ['CONTENT_TYPE' => 'application/json']);
         foreach ($parameters as [$params, $expectedErrors]) {
@@ -125,7 +126,10 @@ class SecureControllerTest extends WebTestCase
                 ['email' => 'This value is already used.'],
             ],
             [
-                ['email' => 'qwerty'],
+                [
+                    'email' => 'qwerty',
+                    'country' => 'United States',
+                ],
                 [
                     'username' => 'This value should not be blank.',
                     'password' => 'This value should not be blank.',
@@ -134,6 +138,7 @@ class SecureControllerTest extends WebTestCase
                     'zip' => 'This value should not be blank.',
                     'email' => 'This value is not a valid email address.',
                     'email_confirm' => 'The email fields must match.',
+                    'country' => 'This value is not a valid country.',
                 ],
             ]
         ];


### PR DESCRIPTION
Uncaught PHP Exception Stripe\Error\InvalidRequest: "Country 'United States' is unknown. Try using a 2-character alphanumeric country code instead, such as 'US', 'EG', or 'GB'. A full list of country codes is available at https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements" at vendor/stripe/stripe-php/lib/ApiRequestor.php line 98